### PR TITLE
Fix example code syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Array inputs, with the frequencies set to low, medium and high respectively.
 ```python
 import numpy as np
 forecast_input = [
-    np.sin(np.linspace(0, 20, 100))
+    np.sin(np.linspace(0, 20, 100)),
     np.sin(np.linspace(0, 20, 200)),
     np.sin(np.linspace(0, 20, 400)),
 ]


### PR DESCRIPTION
Fixes invalid syntax error in example code caused by a missing `,`