### PR TITLE
Fix importing patch_decoder

### DIFF
--- a/src/timesfm.py
+++ b/src/timesfm.py
@@ -35,7 +35,7 @@ from praxis import py_utils
 from praxis import pytypes
 from praxis.layers import normalizations
 from praxis.layers import transformers
-from . import patched_decoder
+import patched_decoder
 from utilsforecast.processing import make_future_dataframe
 
 instantiate = base_hyperparams.instantiate


### PR DESCRIPTION
After the latest package fix the `patched_decoder` cannot be imported. The error when executing the code is 

```
File ~/dev/ml-workspace/timesfm/src/timesfm.py:38
        /dev/ml-workspace/timesfm/src/timesfm.py:36) from praxis.layers import normalizations
        /dev/ml-workspace/timesfm/src/timesfm.py:37) from praxis.layers import transformers
---> /dev/ml-workspace/timesfm/src/timesfm.py:38) from . import patched_decoder
        /dev/ml-workspace/timesfm/src/timesfm.py:39) from utilsforecast.processing import make_future_dataframe
        /dev/ml-workspace/timesfm/src/timesfm.py:41) instantiate = base_hyperparams.instantiate

ImportError: attempted relative import with no known parent package```

This small change will fix the import. I've tested this locally. 