### PR TITLE
Revert "Fix importing patch_decoder"

### DIFF
--- a/src/timesfm.py
+++ b/src/timesfm.py
@@ -35,7 +35,7 @@ from praxis import py_utils
 from praxis import pytypes
 from praxis.layers import normalizations
 from praxis.layers import transformers
-import patched_decoder
+from . import patched_decoder
 from utilsforecast.processing import make_future_dataframe
 
 instantiate = base_hyperparams.instantiate


### PR DESCRIPTION
- reverts https://github.com/google-research/timesfm/pull/32

I'm pretty sure that "fix" actually broke this repo as a module

I belive the error `ImportError: attempted relative import with no known parent package` occurs if people try to run `src/timesfm.py` directly
and they might have reason to do so because this reop did not work as a module on it's initial release

adding to this this repo is structured weirdly 
so people might be confused on how they should be using this repo and running the code
- shoud they be cloneing this in ther peoject as a module
- should they colne this project and add they own code into src/
- should they clone this as take parts of the code into the own project

---

timeline

- before `fix code structure` https://github.com/google-research/timesfm/commit/24bd19c74bd6b28eb576437f21b22b20f6536520 this repo only works under several conditions so people migh comewith diffrent creative ways ways of running the code
- after the commit `fix code structure` https://github.com/google-research/timesfm/commit/24bd19c74bd6b28eb576437f21b22b20f6536520 made this reop worked as a module but breaks running itdirectly
- then https://github.com/google-research/timesfm/pull/32 makes src/timesfm.py + src/patched_decoder.py as standload code but breaks this a module

---

- I sugest mergeing this PR reverting https://github.com/google-research/timesfm/pull/32 to make it function as a module for now
- and in the future restructure the project completely to a more typical structure like

```
├── README.md
├── timesfm/            <---- package name
│   ├── __init__.py
│   ├── module.py
│   └── module.py
└── other stuff/
    ├── generate_awesomeness.py
    └── decrease_world_suck.py
```
---

---

the reason I don't perform the restructure myself in this PR is because a the restructure of the project would cause existing users to have issues, my intention is to only get back to a code working state
