### PR TITLE
Use of Pypi 'sklearn' is deprecated and cause error while building.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "jax>=0.4.26",
     "numpy>=1.26.4",
     "pandas>=2.1.4",
-    "sklearn>=1.15.1",
+    "scikit-learn>=1.5.1",
 ]
 authors = [
      {name = "Rajat Sen", email = "senrajat@google.com"},


### PR DESCRIPTION
Couldn't build timesfm because of new dependencies added in pyproject.toml,
Pipy package sklearn is deprecated, replacing it by 'scikit-learn>=1.5.1' solve the problem.
Hope it helps.