### PR TITLE
Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,9 +21,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install poetry
       # use the hardcoded version number for now. if this is merged to the main repo, you can uncomment these lines to automatically tag the version number with the github run number
+      # e.g. poetry version 0.1.${{ github.run_number }}
       - name: Set Version number
         run: |
-          poetry version 0.1.${{ github.run_number }}
+          poetry version 1.1.0
       - name: Build and Publish to PyPI
         run: |
           poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Update to 1.1.x versions. By manually increasing the versioning we disable publishing every time a new PR is merged. Now for a new version to be publish to PyPI one needs to increase the version here as part of the PR. 

PTAL. WDYT?