### PR TITLE
Bump version to 1.2.0 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       # e.g. poetry version 0.1.${{ github.run_number }}
       - name: Set Version number
         run: |
-          poetry version 1.1.0
+          poetry version 1.2.0
       - name: Build and Publish to PyPI
         run: |
           poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Poetry publishing seems to be [stuck](https://github.com/google-research/timesfm/actions/runs/10857027112/job/30132751350#step:6:11) with the latest changes. This just bumps the version to what was listed in the [__init__.py](https://github.com/google-research/timesfm/blob/d065f8c07dc624213732f2b0b41289d3e828b2d3/src/timesfm/__init__.py#L16) so that the package can be published.