### PR TITLE
Extending the TimeSeriesdata class for PyTorch Dataset Generation

### DIFF
--- a/src/timesfm/data_loader.py
+++ b/src/timesfm/data_loader.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""TF dataloaders for general timeseries datasets.
+"""Dataloaders for general timeseries datasets.
 
 The expected input format is csv file with a datetime index.
 """

--- a/src/timesfm/data_loader.py
+++ b/src/timesfm/data_loader.py
@@ -20,7 +20,6 @@ from absl import logging
 import numpy as np
 import pandas as pd
 from sklearn.preprocessing import StandardScaler
-import tensorflow as tf
 from . import time_features
 
 
@@ -244,6 +243,8 @@ class TimeSeriesdata(object):
 
   def tf_dataset(self, mode='train', shift=1):
     """Tensorflow Dataset."""
+    import tensorflow as tf
+
     if mode == 'train':
       gen_fn = self.train_gen
     else:
@@ -252,4 +253,16 @@ class TimeSeriesdata(object):
                          [tf.int32] * 2)
     dataset = tf.data.Dataset.from_generator(gen_fn, output_types)
     dataset = dataset.prefetch(tf.data.experimental.AUTOTUNE)
+    return dataset
+
+  def torch_dataset(self, mode="train", shift=1):
+    """PyTorch Dataset."""
+    from .pytorch_timesfm_iterable_dataset import TimesFmIterableDataset
+
+    if mode == "train":
+      gen_fn = self.train_gen
+    else:
+      gen_fn = lambda: self.test_val_gen(mode, shift)  # noqa: E731
+
+    dataset = TimesFmIterableDataset(gen_fn)
     return dataset

--- a/src/timesfm/pytorch_timesfm_iterable_dataset.py
+++ b/src/timesfm/pytorch_timesfm_iterable_dataset.py
@@ -1,0 +1,46 @@
+from typing import Callable, Generator, Tuple
+
+import numpy as np
+import torch
+from torch.utils.data import IterableDataset
+
+
+class TimesFmIterableDataset(IterableDataset):
+  def __init__(
+    self,
+    generator_fn: Callable[
+      [],
+      Generator[
+        Tuple[
+          np.float32,
+          np.float32,
+          np.int32,
+          np.float32,
+          np.float32,
+          np.int32,
+          np.int32,
+        ],
+        None,
+        None,
+      ],
+    ],
+  ):
+    super().__init__()
+    self._generator_fn = generator_fn
+
+  def _generator_wrapper(self, worker_id: int, num_workers: int):
+    i = 0
+    for data in self._generator_fn():
+      if i % num_workers == worker_id:
+        yield data
+      i += 1
+
+  def __iter__(self):
+    worker_info = torch.utils.data.get_worker_info()
+
+    if worker_info is None:
+      return self._generator_fn()
+
+    worker_id = worker_info.id
+    num_workers = worker_info.num_workers
+    return self._generator_wrapper(worker_id, num_workers)

--- a/src/timesfm/pytorch_timesfm_iterable_dataset.py
+++ b/src/timesfm/pytorch_timesfm_iterable_dataset.py
@@ -1,3 +1,21 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""PyTorch dataset adapter for TimesFM.
+
+This dataset is designed to be used with `timesfm.data_loader.TimeSeriesdata`.
+"""
+
 from typing import Callable, Generator, Tuple
 
 import numpy as np
@@ -6,6 +24,12 @@ from torch.utils.data import IterableDataset
 
 
 class TimesFmIterableDataset(IterableDataset):
+  """PyTorch dataset adapter for TimesFM.
+
+  Args:
+    generator_fn: A function that returns a generator that yields tuples of
+      numpy arrays. For the expected format of the tuples, see `timesfm.data_loader.TimeSeriesdata.train_gen()`.
+  """
   def __init__(
     self,
     generator_fn: Callable[
@@ -29,6 +53,7 @@ class TimesFmIterableDataset(IterableDataset):
     self._generator_fn = generator_fn
 
   def _generator_wrapper(self, worker_id: int, num_workers: int):
+    """Wraps the generator to yield data only for the current worker."""
     i = 0
     for data in self._generator_fn():
       if i % num_workers == worker_id:
@@ -36,6 +61,7 @@ class TimesFmIterableDataset(IterableDataset):
       i += 1
 
   def __iter__(self):
+    """Returns an iterator over the dataset."""
     worker_info = torch.utils.data.get_worker_info()
 
     if worker_info is None:


### PR DESCRIPTION
I am currently working on reproducing [`notebooks/finetuning.ipynb`](https://github.com/google-research/timesfm/blob/c9a582506b7588a39bc11b38b17c0020e5942629/notebooks/finetuning.ipynb) in PyTorch. I noticed that PR #223 added a fine-tuning framework for PyTorch. However, to load datasets like ETT (the dataset used in the Praxis fine-tuning example), we need to create a custom PyTorch dataset class and ensure its implementation aligns with the original one.

This PR slightly modifies `data_loader.py` to provide both TensorFlow and PyTorch datasets.  This allows for greater code reuse and minimizes the discrepancy between implementations in different frameworks.

## Features
1. Reuse the existing data loader code to provide a PyTorch dataset instance.
2. Add an adapter to enable the PyTorch fine-tuning code from PR #223 to use the TimesFM data loader.

## Usage
### Reproduce `notebooks/finetuning.ipynb`
For those who want to reproduce the fine-tuning in [finetuning.ipynb](https://github.com/google-research/timesfm/blob/c9a582506b7588a39bc11b38b17c0020e5942629/notebooks/finetuning.ipynb), a few lines of code change are enough to easily port the data loading section of the Praxis fine-tuning example to the PyTorch version.  
```python
DATA_DICT = {
    "ettm1": {
        "boundaries": [34560, 46080, 57600],
        "data_path": "../datasets/ETT-small/ETTm1.csv",
        "freq": "15min",
    },
}

# ... omitted since the code is not changed ...  

dtl = TimeSeriesdata(
    data_path=data_path,
    datetime_col="date",
    num_cov_cols=num_cov_cols,
    cat_cov_cols=cat_cov_cols,
    ts_cols=np.array(ts_cols),
    train_range=[0, boundaries[0]],
    val_range=[boundaries[0], boundaries[1]],
    test_range=[boundaries[1], boundaries[2]],
    hist_len=context_len,
    pred_len=pred_len,
    batch_size=num_ts,
    freq=freq,
    normalize=True,
    epoch_len=None,
    holiday=False,
    permute=True,
)

# replace `dtl.tf_dataset()` with `dtl.torch_dataset`
train_dataset = dtl.torch_dataset(mode="train", shift=1)
val_dataset = dtl.torch_dataset(mode="val", shift=pred_len)

# define PyTorch data loader, then it can be consumed  in an ordinary PyTorch training loop
train_dataloader = DataLoader(train_batches, batch_size=batch_size)

# ...

# Trainning loop
for epoch in range(NUM_EPOCHS):
    print(f"__________________Epoch: {epoch}__________________", flush=True)
    # ...
    for batch in tqdm(train_dataloader):
        # ...
```

### Load dataset to the PyTorch `TimesFMFinetuner`
For those who want to use the `TimesFMFinetuner`, this PR provides an adapter to convert the existing dataset format to the TimesFMFinetuner dataset format.

```python
from finetuning.finetuning_torch import TimesFMFinetuner, FineTunningDataset

# Define the original dataset like `notebooks/finetuning.ipynb`
dtl = TimeSeriesdata(
    data_path=data_path,
    datetime_col="date",
    num_cov_cols=num_cov_cols,
    cat_cov_cols=cat_cov_cols,
    ts_cols=np.array(ts_cols),
    train_range=[0, boundaries[0]],
    val_range=[boundaries[0], boundaries[1]],
    test_range=[boundaries[1], boundaries[2]],
    hist_len=context_len,
    pred_len=pred_len,
    batch_size=num_ts,
    freq=freq,
    normalize=True,
    epoch_len=None,
    holiday=False,
    permute=True,
)

train_dataset = FineTunningDataset.from_timesfm_iterable_dataset(train_batches, input_patch_len=32)
val_dataset = FineTunningDataset.from_timesfm_iterable_dataset(val_batches, input_patch_len=32)

# ...
finetuner = TimesFMFinetuner(model, config)

# We can directly pass the converted dataset into the finetuner
results = finetuner.finetune(train_dataset=train_dataset, val_dataset=val_dataset)
```