### PR TITLE
Fix timesfm incompatibility with conda environment due different pip …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ python = ">=3.10,<3.11"
 
 [tool.poetry.dependencies.jax]
 version = ">=0.4.26"
-extras = ["cuda12"]
 python = ">=3.10,<3.12"  # Support both python versions
 
 [tool.poetry.dependencies.jaxlib]


### PR DESCRIPTION
…semantic naming

Fixes https://github.com/google-research/timesfm/issues/244

Installation of timefs results to installing another set of cuda-toolkit even if the conda environment is compatible with the requirements as indicated in https://github.com/google-research/timesfm/blob/master/pyproject.toml in more particular `Jax cuda-12 >= 0.4.26`.

This arises because `timesfm` is specifically asking for jax[cuda12] but conda semantic is instead jax+jaxlib-cuda-12 which pip installer does not understand. The cuda is attached to jaxlib in conda.

Removing cuda12 in jax semantic requirement allows the installation to proceed without messing up the existing ja+cuda-12 installations.