### PR TITLE
Refactor GitHub Actions workflow for Poetry publish: update Python ve…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,29 +2,27 @@ name: Poetry publish
 
 on:
   push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
+    tags:
+    - 'v*'
 
 jobs:
   buildPush:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.10'
-      - name: Install Poetry
-        run: |
-          python -m pip install --upgrade pip
-          pip install poetry
-      # use the hardcoded version number for now. if this is merged to the main repo, you can uncomment these lines to automatically tag the version number with the github run number
-      # e.g. poetry version 0.1.${{ github.run_number }}
-      - name: Set Version number
-        run: |
-          poetry version 1.3.0
-      - name: Build and Publish to PyPI
-        run: |
-          poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}
-          poetry publish --build
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.11'
+    - name: Install Poetry
+      run: |
+        python -m pip install --upgrade pip
+        pip install poetry
+    # Set Poetry version from tag name (strip leading 'v')
+    - name: Set Version number from tag
+      run: |
+        poetry version "${GITHUB_REF_NAME#v}"
+    - name: Build and Publish to PyPI
+      run: |
+        poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}
+        poetry publish --build


### PR DESCRIPTION
- build with python 3.11
- trigger pipeline on tags v*
- set pip/poetry publish version to the tag, e.g. v2.0.1