### PR TITLE
Build/Publish on version tag, python 3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
   buildPush:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
- build with python 3.11
- only trigger on tag (e.g. v2.1.0)
- use that tag as poetry/pip version