### PR TITLE
Remove lingvo from v1 pax extra to avoid install failures on Colab

### DIFF
--- a/v1/pyproject.toml
+++ b/v1/pyproject.toml
@@ -42,16 +42,18 @@ absl-py = ">=1.4.0"
 safetensors = "^0.5.3"
 
 [tool.poetry.extras]
-pax = ["paxml", "lingvo", "jax", "jaxlib"]
+# Note: `lingvo` is an optional Google-internal dependency with strict Python
+# version and packaging constraints that cause install failures on some
+# environments (Colab etc.). We omit it from the pax extra here so users can
+# opt-in explicitly if they need it and have a compatible environment.
+pax = ["paxml", "jax", "jaxlib"]
 torch = ["torch"] 
 
 [tool.poetry.dependencies.paxml]
 version = ">=1.4.0"
 python = ">=3.10,<3.11"
 
-[tool.poetry.dependencies.lingvo]
-version = ">=0.12.7"
-python = ">=3.10,<3.11"
+
 
 [tool.poetry.dependencies.jax]
 version = ">=0.4.26"


### PR DESCRIPTION
Fixes #309

- Change: Removed `lingvo` from the `pax` extra and deleted the `lingvo` dependency block in pyproject.toml.  
-  `lingvo` requires a narrow Python version and often has no installable wheel on Colab, causing pip install failures; removing it from the default extras prevents those failures while keeping paxml/jax optional.  