### PR TITLE
Initialize scaling parameter to prevent NaNs in scratch training

### DIFF
--- a/v1/src/timesfm/pytorch_patched_decoder.py
+++ b/v1/src/timesfm/pytorch_patched_decoder.py
@@ -351,7 +351,7 @@ class TimesFMAttention(nn.Module):
     self.q_size = self.num_heads * self.head_dim
     self.kv_size = self.num_kv_heads * self.head_dim
     self.scaling = nn.Parameter(
-        torch.empty((self.head_dim,), dtype=torch.float32),)
+        torch.randn((self.head_dim,), dtype=torch.float32),)
 
     self.qkv_proj = nn.Linear(
         self.hidden_size,


### PR DESCRIPTION
## Description

The self.scaling parameter is created using torch.empty and is then used without being initialized.
This is not a problem during finetuning, because pretrained checkpoints provide valid scaling parameters.
But when **training from scratch**, these undefined values may occasionally cause numerical instability and lead to NaN outputs.
Initializing `self.scaling` with `torch.randn` ensures proper initial values and improves training stability.

## List of changes

- Initialize `self.scaling` with `torch.randn`.

## For reviewers

- No functionality change, just fixed parameter initialization.