### PR TITLE
feat: add tqdm progress bars to TimesFMFinetuner

### DIFF
--- a/v1/pyproject.toml
+++ b/v1/pyproject.toml
@@ -38,6 +38,7 @@ huggingface_hub = { version = ">=0.23.0", extras = ["cli"] }
 scikit-learn = ">=1.2.2"
 typer = ">=0.12.3"
 wandb = ">=0.17.5"
+tqdm = ">=4.62.0"
 absl-py = ">=1.4.0"
 safetensors = "^0.5.3"
 

--- a/v1/src/finetuning/finetuning_torch.py
+++ b/v1/src/finetuning/finetuning_torch.py
@@ -140,6 +140,8 @@ class FinetuningConfig:
       val_check_interval: How often within one training epoch to check val metrics. (also from Pytorch Lightning)
         Can be: float (0.0-1.0): fraction of epoch (e.g., 0.5 = validate twice per epoch)
                 int: validate every N batches
+      progress_bar: Whether to display tqdm progress bars during training and
+        validation. Only shown on rank 0 in distributed training.
     """
 
   batch_size: int = 32
@@ -296,7 +298,7 @@ class TimesFMFinetuner:
     is_main = not self.config.distributed or dist.get_rank() == 0
     loader = tqdm(train_loader, desc="Training", leave=False) if self.config.progress_bar and is_main else train_loader
 
-    for batch in loader:
+    for batch_idx, batch in enumerate(loader):
       loss, _ = self._process_batch(batch)
 
       optimizer.zero_grad()
@@ -306,7 +308,9 @@ class TimesFMFinetuner:
       total_loss += loss.item()
 
       if self.config.progress_bar and is_main and hasattr(loader, "set_postfix"):
-        loader.set_postfix(loss=loss.item())
+        if (batch_idx + 1) % self.config.log_every_n_steps == 0 or batch_idx == num_batches - 1:
+          avg_loss = total_loss / (batch_idx + 1)
+          loader.set_postfix(loss=avg_loss)
 
     avg_loss = total_loss / num_batches
 

--- a/v1/src/finetuning/finetuning_torch.py
+++ b/v1/src/finetuning/finetuning_torch.py
@@ -15,6 +15,7 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import DataLoader, Dataset
 from timesfm.pytorch_patched_decoder import create_quantiles
 
+from tqdm import tqdm
 import wandb
 
 
@@ -157,6 +158,7 @@ class FinetuningConfig:
   wandb_project: str = "timesfm-finetuning"
   log_every_n_steps: int = 50
   val_check_interval: float = 0.5
+  progress_bar: bool = True
 
 
 class TimesFMFinetuner:
@@ -291,7 +293,10 @@ class TimesFMFinetuner:
     total_loss = 0.0
     num_batches = len(train_loader)
 
-    for batch in train_loader:
+    is_main = not self.config.distributed or dist.get_rank() == 0
+    loader = tqdm(train_loader, desc="Training", leave=False) if self.config.progress_bar and is_main else train_loader
+
+    for batch in loader:
       loss, _ = self._process_batch(batch)
 
       optimizer.zero_grad()
@@ -299,6 +304,9 @@ class TimesFMFinetuner:
       optimizer.step()
 
       total_loss += loss.item()
+
+      if self.config.progress_bar and is_main and hasattr(loader, "set_postfix"):
+        loader.set_postfix(loss=loss.item())
 
     avg_loss = total_loss / num_batches
 
@@ -322,8 +330,11 @@ class TimesFMFinetuner:
     total_loss = 0.0
     num_batches = len(val_loader)
 
+    is_main = not self.config.distributed or dist.get_rank() == 0
+    loader = tqdm(val_loader, desc="Validating", leave=False) if self.config.progress_bar and is_main else val_loader
+
     with torch.no_grad():
-      for batch in val_loader:
+      for batch in loader:
         loss, _ = self._process_batch(batch)
         total_loss += loss.item()
 


### PR DESCRIPTION
## Summary
Add optional tqdm progress bars to `TimesFMFinetuner` training and validation loops.

- Add `progress_bar: bool = True` flag to `FinetuningConfig`
- Wrap `_train_epoch` and `_validate` DataLoader loops with tqdm (rank 0 only)
- Show running loss via `set_postfix` during training
- Default `True`, can be disabled with `config.progress_bar = False`

Fixes #289

## Changes
| File | Change |
|---|---|
| `v1/src/finetuning/finetuning_torch.py` | Add tqdm import, config flag, and progress bar wrapping |