### PR TITLE
fix: per-input covariate normalization in forecast_with_covariates

### DIFF
--- a/src/timesfm/utils/xreg_lib.py
+++ b/src/timesfm/utils/xreg_lib.py
@@ -370,11 +370,20 @@ class BatchedInContextXRegBase:
       x_train = np.concatenate(x_train, axis=1)
       x_test = np.concatenate(x_test, axis=1)
 
-      # Normalize for robustness.
-      x_mean = np.mean(x_train, axis=0, keepdims=True)
-      x_std = np.where((w := np.std(x_train, axis=0, keepdims=True)) > _TOL, w, 1.0)
-      x_train = [(x_train - x_mean) / x_std]
-      x_test = [(x_test - x_mean) / x_std]
+      # Normalize per-input for robustness (batch-wide normalization
+      # would make each input's result depend on batch composition).
+      train_splits = np.cumsum(self.train_lens)[:-1]
+      test_splits = np.cumsum(self.test_lens)[:-1]
+      train_parts = np.split(x_train, train_splits, axis=0)
+      test_parts = np.split(x_test, test_splits, axis=0)
+      norm_train, norm_test = [], []
+      for tr, te in zip(train_parts, test_parts):
+        m = np.mean(tr, axis=0, keepdims=True)
+        s = np.where((w := np.std(tr, axis=0, keepdims=True)) > _TOL, w, 1.0)
+        norm_train.append((tr - m) / s)
+        norm_test.append((te - m) / s)
+      x_train = [np.concatenate(norm_train, axis=0)]
+      x_test = [np.concatenate(norm_test, axis=0)]
 
     # Categorical features. Encode one by one.
     one_hot_encoder = preprocessing.OneHotEncoder(

--- a/v1/src/timesfm/xreg_lib.py
+++ b/v1/src/timesfm/xreg_lib.py
@@ -339,12 +339,20 @@ class BatchedInContextXRegBase:
       x_train = np.concatenate(x_train, axis=1)
       x_test = np.concatenate(x_test, axis=1)
 
-      # Normalize for robustness.
-      x_mean = np.mean(x_train, axis=0, keepdims=True)
-      x_std = np.where((w := np.std(x_train, axis=0, keepdims=True)) > _TOL, w,
-                       1.0)
-      x_train = [(x_train - x_mean) / x_std]
-      x_test = [(x_test - x_mean) / x_std]
+      # Normalize per-input for robustness (batch-wide normalization
+      # would make each input's result depend on batch composition).
+      train_splits = np.cumsum(self.train_lens)[:-1]
+      test_splits = np.cumsum(self.test_lens)[:-1]
+      train_parts = np.split(x_train, train_splits, axis=0)
+      test_parts = np.split(x_test, test_splits, axis=0)
+      norm_train, norm_test = [], []
+      for tr, te in zip(train_parts, test_parts):
+        m = np.mean(tr, axis=0, keepdims=True)
+        s = np.where((w := np.std(tr, axis=0, keepdims=True)) > _TOL, w, 1.0)
+        norm_train.append((tr - m) / s)
+        norm_test.append((te - m) / s)
+      x_train = [np.concatenate(norm_train, axis=0)]
+      x_test = [np.concatenate(norm_test, axis=0)]
 
     # Categorical features. Encode one by one.
     one_hot_encoder = preprocessing.OneHotEncoder(


### PR DESCRIPTION
## Summary

`forecast_with_covariates` produces different forecast results for the same input depending on which other inputs are in the batch. This violates forecast isolation and breaks backtesting workflows.

## Root cause

In `create_covariate_matrix()` (`xreg_lib.py:373-377`), normalization statistics (mean/std) are computed across all inputs in the batch after `_unnest()` flattens them into a single array. When batch composition changes, normalization changes, which alters regression coefficients and forecast output.

Credit to @aydinomer00 for [identifying the root cause](https://github.com/google-research/timesfm/issues/274#issuecomment-2869279730).

## Changes

Split the flattened covariate arrays by `train_lens`/`test_lens` boundaries, normalize each input independently using its own mean/std, then recombine. Applied to both `src/timesfm/utils/xreg_lib.py` and `v1/src/timesfm/xreg_lib.py`.

The fix uses `np.split()` with cumulative sums of `train_lens` to recover per-input boundaries, computes normalization per segment, and applies each input's train statistics to its corresponding test segment.

## Testing

Verified that the changed code paths are exercised by `BatchedInContextXRegLinear.fit()`, which is the entry point for `forecast_with_covariates`. The normalization now produces identical results for a given input regardless of what else is in the batch.

Fixes #274, relates to #338, #262

This contribution was developed with AI assistance (Codex).