### PR TITLE
fix: correct docstring typo and replace print with logging

### DIFF
--- a/src/timesfm/configs.py
+++ b/src/timesfm/configs.py
@@ -23,11 +23,11 @@ class ForecastConfig:
   """Options for forecasting.
 
   Attributes:
-    max_context: The maximum context length. This is used by the complied decode
+    max_context: The maximum context length. This is used by the compiled decode
       function at inference time during batched inference. Any input time series
       with length less than max_context will be padded with zeros, and with
       length greater than max_context will be truncated.
-    max_horizon: The maximum horizon length. This is used by the complied decode
+    max_horizon: The maximum horizon length. This is used by the compiled decode
       function at inference time during batched inference. The compiled cached
       decoding function will by default forecast till max_horizon.
     normalize_inputs: Whether to normalize the inputs. This is useful when the

--- a/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py
+++ b/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py
@@ -85,7 +85,7 @@ class TimesFM_2p5_200M_torch_module(nn.Module):
     if "torch_compile" in kwargs:
       torch_compile = kwargs["torch_compile"]
     if torch_compile:
-      print("Compiling model...")
+      logging.info("Compiling model...")
       self = torch.compile(self)
 
     self.eval()


### PR DESCRIPTION
Two small fixes in separate commits:

### Commit 1: correct 'complied' typo in ForecastConfig docstring

`src/timesfm/configs.py` — The `max_context` and `max_horizon` attribute docstrings both reference a *"complied decode function"*. The correct word is **"compiled"**.

### Commit 2: replace `print` with `logging.info` in checkpoint loader

`src/timesfm/timesfm_2p5/timesfm_2p5_torch.py` — The `load_checkpoint` method used `print("Compiling model...")` while the rest of the same file consistently uses the `logging` module (e.g. `logging.info` on lines 313, 320, 334). This change makes the message controllable via standard Python logging configuration and avoids unconditional writes to stdout when `timesfm` is used as a library.