### PR TITLE
fix: accept Hugging Face Hub download kwargs

### DIFF
--- a/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py
+++ b/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py
@@ -297,6 +297,8 @@ class TimesFM_2p5_200M_torch(
     revision: Optional[str],
     cache_dir: Optional[Union[str, Path]],
     force_download: bool = False,
+    proxies: Optional[dict] = None,
+    resume_download: Optional[bool] = None,
     local_files_only: bool,
     token: Optional[Union[str, bool]],
     config: Optional[dict] = None,
@@ -324,6 +326,8 @@ class TimesFM_2p5_200M_torch(
         revision=revision,
         cache_dir=cache_dir,
         force_download=force_download,
+        proxies=proxies,
+        resume_download=resume_download,
         token=token,
         local_files_only=local_files_only,
       )

--- a/tests/test_hfhub_compat.py
+++ b/tests/test_hfhub_compat.py
@@ -1,0 +1,69 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from timesfm.timesfm_2p5 import timesfm_2p5_torch
+
+
+class _DummyModel:
+
+  def __init__(self):
+    self.calls = []
+
+  def load_checkpoint(self, path, **kwargs):
+    self.calls.append((path, kwargs))
+
+
+class _DummyTimesFM(timesfm_2p5_torch.TimesFM_2p5_200M_torch):
+
+  def __init__(self, torch_compile=True, config=None):
+    self.model = _DummyModel()
+    self.torch_compile = torch_compile
+    if config is not None:
+      self._hub_mixin_config = config
+
+
+def test_from_pretrained_accepts_hf_hub_v1_kwargs(monkeypatch):
+  captured = {}
+
+  def fake_hf_hub_download(**kwargs):
+    captured.update(kwargs)
+    return "C:/fake/model.safetensors"
+
+  monkeypatch.setattr(timesfm_2p5_torch, "hf_hub_download", fake_hf_hub_download)
+
+  instance = _DummyTimesFM._from_pretrained(
+    model_id="google/timesfm-2.5-200m-pytorch",
+    revision="main",
+    cache_dir="C:/cache",
+    force_download=False,
+    proxies={"https": "https://proxy.example"},
+    resume_download=None,
+    local_files_only=True,
+    token="token",
+  )
+
+  assert captured == {
+    "repo_id": "google/timesfm-2.5-200m-pytorch",
+    "filename": _DummyTimesFM.WEIGHTS_FILENAME,
+    "revision": "main",
+    "cache_dir": "C:/cache",
+    "force_download": False,
+    "proxies": {"https": "https://proxy.example"},
+    "resume_download": None,
+    "token": "token",
+    "local_files_only": True,
+  }
+  assert instance.model.calls == [
+    ("C:/fake/model.safetensors", {"torch_compile": True}),
+  ]


### PR DESCRIPTION
## Summary
Accept the Hub download kwargs that `PyTorchModelHubMixin` may forward in newer `huggingface_hub` releases and pass them through to `hf_hub_download`.

## Why
`_from_pretrained()` currently does not consume `proxies` and `resume_download`, so they fall through `**model_kwargs` and get forwarded into the model constructor instead. That breaks `from_pretrained()` compatibility with Hub 1.x style calls.

Fixes #334.

## Testing
- Added `tests/test_hfhub_compat.py`
- Ran `PYTHONPATH=src python -m pytest tests/test_hfhub_compat.py -q`
