### PR TITLE
fix: retain compiled torch model after load

### DIFF
--- a/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py
+++ b/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py
@@ -81,13 +81,6 @@ class TimesFM_2p5_200M_torch_module(nn.Module):
     tensors = load_file(path)
     self.load_state_dict(tensors, strict=True)
     self.to(self.device)
-    torch_compile = True
-    if "torch_compile" in kwargs:
-      torch_compile = kwargs["torch_compile"]
-    if torch_compile:
-      print("Compiling model...")
-      self = torch.compile(self)
-
     self.eval()
 
   def forward(
@@ -333,9 +326,10 @@ class TimesFM_2p5_200M_torch(
 
     logging.info("Loading checkpoint from: %s", model_file_path)
     # Load the weights into the model.
-    instance.model.load_checkpoint(
-      model_file_path, torch_compile=instance.torch_compile
-    )
+    instance.model.load_checkpoint(model_file_path)
+    if instance.torch_compile:
+      instance.model = torch.compile(instance.model)
+      instance.model.eval()
     return instance
 
   def _save_pretrained(self, save_directory: Union[str, Path]):

--- a/tests/test_torch_compile_retention.py
+++ b/tests/test_torch_compile_retention.py
@@ -1,0 +1,83 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from torch import nn
+
+from timesfm.timesfm_2p5 import timesfm_2p5_torch
+
+
+class _CompiledModel:
+
+  def __init__(self):
+    self.eval_called = False
+
+  def eval(self):
+    self.eval_called = True
+    return self
+
+
+class _DummyModel(nn.Module):
+  load_checkpoint = timesfm_2p5_torch.TimesFM_2p5_200M_torch_module.load_checkpoint
+
+  def __init__(self):
+    super().__init__()
+    self.device = torch.device("cpu")
+    self.state_dict_calls = []
+    self.to_calls = []
+    self.eval_called = False
+
+  def load_state_dict(self, tensors, strict=True):
+    self.state_dict_calls.append((tensors, strict))
+
+  def to(self, device):
+    self.to_calls.append(device)
+    return self
+
+  def eval(self):
+    self.eval_called = True
+    return self
+
+
+class _DummyTimesFM(timesfm_2p5_torch.TimesFM_2p5_200M_torch):
+
+  def __init__(self, torch_compile=True, config=None):
+    self.model = _DummyModel()
+    self.torch_compile = torch_compile
+    if config is not None:
+      self._hub_mixin_config = config
+
+
+def test_from_pretrained_retains_compiled_model(monkeypatch):
+  compiled_model = _CompiledModel()
+
+  monkeypatch.setattr(timesfm_2p5_torch, "load_file", lambda path: {"w": 1})
+  monkeypatch.setattr(
+    timesfm_2p5_torch,
+    "hf_hub_download",
+    lambda **kwargs: "C:/fake/model.safetensors",
+  )
+  monkeypatch.setattr(torch, "compile", lambda model: compiled_model)
+
+  instance = _DummyTimesFM._from_pretrained(
+    model_id="google/timesfm-2.5-200m-pytorch",
+    revision="main",
+    cache_dir="C:/cache",
+    force_download=False,
+    local_files_only=True,
+    token=None,
+  )
+
+  assert instance.model is compiled_model
+  assert compiled_model.eval_called


### PR DESCRIPTION
## Summary
Retain the compiled wrapper on `instance.model` when `torch_compile=True` instead of compiling inside `load_checkpoint()`.

## Why
`load_checkpoint()` currently does `self = torch.compile(self)`, which only rebinds the local name. The compiled wrapper is evaluated, but it is discarded when the method returns, so callers keep using the original uncompiled module.

Related to #313.

## Testing
- Added `tests/test_torch_compile_retention.py`
- Ran `PYTHONPATH=src python -m pytest tests/test_torch_compile_retention.py -q`
