### PR TITLE
fix: correct NaN preprocessing and torch.compile dead assignment

### DIFF
--- a/src/timesfm/timesfm_2p5/timesfm_2p5_base.py
+++ b/src/timesfm/timesfm_2p5/timesfm_2p5_base.py
@@ -42,6 +42,8 @@ def strip_leading_nans(arr):
   """
 
   isnan = np.isnan(arr)
+  if isnan.all():
+    return arr[:0]
   first_valid_index = np.argmax(~isnan)
   return arr[first_valid_index:]
 
@@ -73,10 +75,7 @@ def linear_interpolation(arr):
   try:
     arr[nans] = np.interp(nans_indices, non_nans_indices, non_nans_values)
   except ValueError:
-    if non_nans_values:
-      mu = np.nanmean(arr)
-    else:
-      mu = 0.0
+    mu = np.nanmean(arr) if non_nans_values.size > 0 else 0.0
     arr = np.where(np.isfinite(arr), arr, mu)
   return arr
 

--- a/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py
+++ b/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py
@@ -76,18 +76,11 @@ class TimesFM_2p5_200M_torch_module(nn.Module):
       self.device = torch.device("cpu")
       self.device_count = 1
 
-  def load_checkpoint(self, path: str, **kwargs):
+  def load_checkpoint(self, path: str):
     """Loads a PyTorch TimesFM model from a checkpoint."""
     tensors = load_file(path)
     self.load_state_dict(tensors, strict=True)
     self.to(self.device)
-    torch_compile = True
-    if "torch_compile" in kwargs:
-      torch_compile = kwargs["torch_compile"]
-    if torch_compile:
-      print("Compiling model...")
-      self = torch.compile(self)
-
     self.eval()
 
   def forward(
@@ -333,9 +326,10 @@ class TimesFM_2p5_200M_torch(
 
     logging.info("Loading checkpoint from: %s", model_file_path)
     # Load the weights into the model.
-    instance.model.load_checkpoint(
-      model_file_path, torch_compile=instance.torch_compile
-    )
+    instance.model.load_checkpoint(model_file_path)
+    if instance.torch_compile:
+      print("Compiling model...")
+      instance.model = torch.compile(instance.model)
     return instance
 
   def _save_pretrained(self, save_directory: Union[str, Path]):

--- a/v1/src/timesfm/timesfm_base.py
+++ b/v1/src/timesfm/timesfm_base.py
@@ -87,6 +87,8 @@ def strip_leading_nans(arr):
   """
 
   isnan = np.isnan(arr)
+  if isnan.all():
+    return arr[:0]
   first_valid_index = np.argmax(~isnan)
   return arr[first_valid_index:]
 


### PR DESCRIPTION
## Summary

Three silent bugs in the inference preprocessing path, all present in the current `main`:

**1. `strip_leading_nans` returns the wrong value for all-NaN input** (`src/` and `v1/`)

`np.argmax(~isnan)` returns `0` when the input is entirely NaN (all-`False` mask — NumPy does not raise). So `arr[0:]` silently returns the full NaN array instead of the empty array the docstring promises. Downstream, `linear_interpolation` converts the NaN array to all-zeros via `np.where(np.isfinite(...), ..., 0.0)`, and the model receives a plausible-looking but meaningless zero-padded context with no error.

```python
# Reproduce
import numpy as np
arr = np.full(5, np.nan)
isnan = np.isnan(arr)
print(np.argmax(~isnan))  # 0  — looks like a valid index, is not
print(arr[0:])            # [nan nan nan nan nan]  — should be []
```

**2. `linear_interpolation` uses ambiguous bool coercion on a NumPy array** (`src/`)

The `except ValueError` fallback does `if non_nans_values:` where `non_nans_values` is a NumPy array. NumPy already emits `DeprecationWarning` for truth-value testing of arrays with more than one element; a future release will raise `ValueError`. The v1 version of this function already uses `len(...) > 0` — the 2.5 version regressed. Changed to `.size > 0` to match.

**3. `torch.compile` dead assignment in `load_checkpoint`** (`src/`, PyTorch backend)

```python
# In TimesFM_2p5_200M_torch_module.load_checkpoint:
self = torch.compile(self)   # only rebinds the local variable
```

Rebinding `self` inside a method never affects the caller's reference. `torch.compile` returns a new `OptimizedModule` wrapper; assigning it to the local `self` discards it immediately. Since `torch_compile=True` is the **default**, every PyTorch user was getting unoptimized inference while believing the model was compiled.

Moved the `torch.compile` call to `_from_pretrained` where `instance.model = torch.compile(instance.model)` actually takes effect.

## Changes

| File | Change |
|------|--------|
| `src/timesfm/timesfm_2p5/timesfm_2p5_base.py` | Guard in `strip_leading_nans`; fix bool coercion in `linear_interpolation` |
| `v1/src/timesfm/timesfm_base.py` | Guard in `strip_leading_nans` |
| `src/timesfm/timesfm_2p5/timesfm_2p5_torch.py` | Move `torch.compile` to `_from_pretrained`; simplify `load_checkpoint` |
