### PR TITLE
fix: add MPS (Apple Silicon) support for PyTorch backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ results/
 uv.lock
 development_setup.md
 debug.log
+test_mac.py
+test_output.txt

--- a/src/timesfm/timesfm_2p5/timesfm_2p5_base.py
+++ b/src/timesfm/timesfm_2p5/timesfm_2p5_base.py
@@ -165,7 +165,9 @@ class TimesFM_2p5:
     context = self.forecast_config.max_context
     num_inputs = len(inputs)
     if (w := num_inputs % self.global_batch_size) != 0:
-      inputs += [np.array([0.0] * 3)] * (self.global_batch_size - w)
+      inputs += [np.array([0.0] * 3, dtype=np.float32)] * (
+        self.global_batch_size - w
+      )
 
     output_points = []
     output_quantiles = []

--- a/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py
+++ b/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py
@@ -72,6 +72,9 @@ class TimesFM_2p5_200M_torch_module(nn.Module):
     if torch.cuda.is_available():
       self.device = torch.device("cuda:0")
       self.device_count = torch.cuda.device_count()
+    elif torch.backends.mps.is_available():
+      self.device = torch.device("mps")
+      self.device_count = 1
     else:
       self.device = torch.device("cpu")
       self.device_count = 1
@@ -414,9 +417,9 @@ class TimesFM_2p5_200M_torch(
         )
 
       inputs = (
-        torch.from_numpy(np.array(inputs)).to(self.model.device).to(torch.float32)
+        torch.from_numpy(np.array(inputs)).to(torch.float32).to(self.model.device)
       )
-      masks = torch.from_numpy(np.array(masks)).to(self.model.device).to(torch.bool)
+      masks = torch.from_numpy(np.array(masks)).to(torch.bool).to(self.model.device)
       batch_size = inputs.shape[0]
 
       if fc.infer_is_positive:

--- a/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py
+++ b/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py
@@ -72,6 +72,9 @@ class TimesFM_2p5_200M_torch_module(nn.Module):
     if torch.cuda.is_available():
       self.device = torch.device("cuda:0")
       self.device_count = torch.cuda.device_count()
+    elif torch.backends.mps.is_available():
+      self.device = torch.device("mps")
+      self.device_count = 1
     else:
       self.device = torch.device("cpu")
       self.device_count = 1
@@ -400,9 +403,9 @@ class TimesFM_2p5_200M_torch(
         )
 
       inputs = (
-        torch.from_numpy(np.array(inputs)).to(self.model.device).to(torch.float32)
+        torch.from_numpy(np.array(inputs)).to(torch.float32).to(self.model.device)
       )
-      masks = torch.from_numpy(np.array(masks)).to(self.model.device).to(torch.bool)
+      masks = torch.from_numpy(np.array(masks)).to(torch.bool).to(self.model.device)
       batch_size = inputs.shape[0]
 
       if fc.infer_is_positive:


### PR DESCRIPTION
## Summary

- **Auto-detect MPS device** in `TimesFM_2p5_200M_torch_module.__init__`: adds an `elif torch.backends.mps.is_available()` branch so Apple Silicon GPUs are used automatically, without requiring any manual workaround from callers.
- **Fix tensor dtype conversion order** in `timesfm_2p5_torch.py`: convert to `float32`/`bool` *before* moving to device (was `.to(device).to(float32)`). MPS does not support `float64`, so the previous order raised `Cannot convert a MPS Tensor to float64` when NumPy's default `float64` arrays were moved to MPS first.
- **Fix padding array dtype** in `timesfm_2p5_base.py`: explicitly pass `dtype=np.float32` when creating padding arrays, preventing NumPy's implicit `float64` promotion from propagating into the model.

## Test plan

- [ ] Run inference on Apple Silicon Mac (`torch.backends.mps.is_available() == True`) and confirm no `float64` errors
- [ ] Confirm existing CUDA and CPU paths are unaffected (device detection logic unchanged for those branches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)