### PR TITLE
ci: run unit tests on every push/PR; fix print→logging in flax compile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Python package build
+name: Python package build and test
 
 on:
   push:
@@ -26,3 +26,22 @@ jobs:
           uv pip install build ".[torch,flax]"
       - name: Build package
         run: uv run python -m build
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - name: Install package with test dependencies
+        run: |
+          uv pip install -e ".[torch]" pytest
+      - name: Run unit tests
+        run: |
+          python -m pytest tests/ -v

--- a/src/timesfm/timesfm_2p5/timesfm_2p5_flax.py
+++ b/src/timesfm/timesfm_2p5/timesfm_2p5_flax.py
@@ -497,8 +497,8 @@ class TimesFM_2p5_200M_flax(timesfm_2p5_base.TimesFM_2p5):
     dryrun: bool = True,
     **kwargs
   ):
-    # Acrobym used during validation.
-    print("Compiling model...")
+    # Acronym used during validation.
+    logging.info("Compiling model...")
 
     fc = forecast_config
     if fc.max_context % self.model.p != 0:
@@ -599,4 +599,4 @@ class TimesFM_2p5_200M_flax(timesfm_2p5_base.TimesFM_2p5):
           (self.global_batch_size, self.forecast_config.max_context), dtype=jnp.bool
         ),
       )
-    print("Compiling done.")
+    logging.info("Compiling done.")


### PR DESCRIPTION
## Summary

- **Add a `test` CI job** to `.github/workflows/main.yml` that installs the torch extras and runs `pytest tests/ -v` on every push and PR. The repository already ships 58 unit tests (configs, NaN utilities, torch layers, torch utilities) that were never executed in CI — silent regressions could be merged undetected.
- **Replace `print()` with `logging.info()`** in the two `compile` log lines inside `TimesFM_2p5_200M_flax.compile`. PR #396 fixed the equivalent calls in the PyTorch backend (`timesfm_2p5_torch.py`) but the Flax backend was left with bare prints. Both calls are now consistent with the rest of the codebase.
- **Fix "Acrobym" typo** in the inline comment to "Acronym".

## Why the test job matters

The current workflow only validates that the package *builds*; it never verifies that existing tests *pass*. Open PRs like #401 (NaN preprocessing fixes) and #399 (HF Hub kwargs) would break or fix tests without CI catching it. This job closes that feedback loop while remaining a minimal, self-contained change — deliberately narrower than the full test-matrix overhaul in PR #404 so it can land independently.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/main.yml` | Add `test` job; install `.[torch]` + pytest; run `pytest tests/ -v` |
| `src/timesfm/timesfm_2p5/timesfm_2p5_flax.py` | `print` → `logging.info` for compile start/done; fix "Acrobym" typo |

## Testing

All 58 existing tests pass locally:

```
$ python -m pytest tests/ -v
...
58 passed in 1.21s
```

The test job uses the same `uv pip install -e ".[torch]" pytest` approach already used in the build job — no model weights or GPU required for these unit tests.