### PR TITLE
Fix TypeError on from_pretrained from huggingface_hub kwargs

### DIFF
--- a/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py
+++ b/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py
@@ -328,6 +328,11 @@ class TimesFM_2p5_200M_torch(
         local_files_only=local_files_only,
       )
 
+    # huggingface_hub forwards download kwargs (proxies, resume_download, ...)
+    # via **model_kwargs; strip them so they don't reach cls.__init__.
+    for k in ("proxies", "resume_download"):
+      model_kwargs.pop(k, None)
+
     # Create an instance of the model wrapper class.
     instance = cls(config=config, **model_kwargs)
 


### PR DESCRIPTION
## Summary

`TimesFM_2p5_200M_torch.from_pretrained(...)` raises:

    TypeError: TimesFM_2p5_200M_torch.__init__() got an unexpected keyword argument 'proxies'

## Root cause

`huggingface_hub.PyTorchModelHubMixin.from_pretrained` always forwards download-related kwargs (`proxies`, `resume_download`) into `_from_pretrained`. In `TimesFM_2p5_200M_torch._from_pretrained`, these end up in `**model_kwargs`, which is then unpacked into the class constructor:

    instance = cls(config=config, **model_kwargs)

But `__init__` only accepts `(torch_compile, config)`, so the call raises.

## Reproducer

```python
import timesfm
timesfm.TimesFM_2p5_200M_torch.from_pretrained("google/timesfm-2.5-200m-pytorch")
```

Reproduces on `huggingface_hub >= 0.23` (which is timesfm's own minimum), so this affects every install of the current master.

## Fix

Strip the known download-only kwargs before constructing the instance. Minimal change.

## Test

Locally verified that `TimesFM_2p5_200M_torch.from_pretrained("google/timesfm-2.5-200m-pytorch")` constructs successfully where it previously raised.