### PR TITLE
Use quotes in zsh macos '.[torch]' or ".[flax]" when using uv pip install 

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Since the Sept. 2025 launch, the following improvements have been completed:
     
     # Install the package in editable mode with torch
     uv pip install -e .[torch]
+    # On zsh (macos), quote extra specifier like '.[torch]' or ".[flax]"
+    uv pip install -e '.[torch]'
     # Or with flax
     uv pip install -e .[flax]
     # Or XReg is needed


### PR DESCRIPTION
On macOS `zsh` terminal, extra syntax like `.[torch]` is interpreted as a glob pattern unless quoted. This causes installation to fail with:

```shell
zsh: no matches found: .[torch]
```
Solution: Quote the extras specifier like this '.[torch]' or ".[flax]"
```
uv pip install -e '.[torch]'
uv pip install -e ".[flax]"
```
