### PR TITLE
chore: ship PEP 561 py.typed marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,6 @@ indent-width = 2
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.package-data]
+timesfm = ["py.typed"]
+


### PR DESCRIPTION
## Summary

Adds an empty `src/timesfm/py.typed` marker file (PEP 561) and includes
it in the built wheel via `[tool.setuptools.package-data]`.

## Why

Without the marker, downstream type checkers (mypy, pyright, pylance)
treat every symbol imported from `timesfm` as `Any` — ignoring the
inline annotations that are already present throughout `configs.py`,
`timesfm_2p5/*.py`, `torch/*.py`, and `flax/*.py`. Shipping the marker
lets users get type information from `timesfm` in their typed
codebases.

PEP 561 explicitly allows partially-typed packages, so no annotation
work is required alongside this change — symbols that are unannotated
will continue to be inferred as `Any`, exactly as they are today for
the package's own internal type-checking.

## Verification

Built the wheel locally and confirmed the marker is included:

```
$ python -m build --wheel
...
Successfully built timesfm-2.0.0-py3-none-any.whl

$ unzip -l dist/timesfm-2.0.0-py3-none-any.whl | grep py.typed
    0  ...  timesfm/py.typed
```

## Test plan

- [x] `python -m build --wheel` succeeds
- [x] `py.typed` is present in the wheel under `timesfm/`
- [x] CI build job (`.github/workflows/main.yml`) passes