### PR TITLE
fix(torch): strip Hugging Face download kwargs in from_pretrained

### DIFF
--- a/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py
+++ b/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py
@@ -342,6 +342,11 @@ class TimesFM_2p5_200M_torch(
         local_files_only=local_files_only,
       )
 
+    # huggingface_hub forwards download kwargs (proxies, resume_download, ...)
+    # via **model_kwargs; strip them so they don't reach cls.__init__.
+    for k in ("proxies", "resume_download", "paper_url"):
+      model_kwargs.pop(k, None)
+
     # Create an instance of the model wrapper class.
     instance = cls(config=config, **model_kwargs)
 


### PR DESCRIPTION
## Summary
- Strip `proxies`, `resume_download`, and `paper_url` from `**model_kwargs` in `TimesFM_2p5_200M_torch._from_pretrained` before calling `cls.__init__`
- Prevents `TypeError: got an unexpected keyword argument 'proxies'` when loading via `from_pretrained()` with Hugging Face Hub download kwargs

Fixes #412

## Test plan
- [x] Verified local `from_pretrained(..., proxies={...}, resume_download=False)` succeeds after the change
- [ ] CI


Made with [Cursor](https://cursor.com)