### PR TITLE
Fix: `torch.compile` was a no-op in `load_checkpoint`

### DIFF
--- a/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py
+++ b/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py
@@ -294,8 +294,9 @@ class TimesFM_2p5_200M_torch(
     else:
       model_file_path = path
 
+    torch_compile = kwargs.pop("torch_compile", self.torch_compile)
     self.model.load_checkpoint(model_file_path, **kwargs)
-    if self.torch_compile:
+    if torch_compile:
       logging.info("Compiling model...")
       self.model.forward = torch.compile(self.model.forward)
 

--- a/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py
+++ b/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py
@@ -81,13 +81,6 @@ class TimesFM_2p5_200M_torch_module(nn.Module):
     tensors = load_file(path)
     self.load_state_dict(tensors, strict=True)
     self.to(self.device)
-    torch_compile = True
-    if "torch_compile" in kwargs:
-      torch_compile = kwargs["torch_compile"]
-    if torch_compile:
-      logging.info("Compiling model...")
-      self = torch.compile(self)
-
     self.eval()
 
   def forward(
@@ -302,6 +295,9 @@ class TimesFM_2p5_200M_torch(
       model_file_path = path
 
     self.model.load_checkpoint(model_file_path, **kwargs)
+    if self.torch_compile:
+      logging.info("Compiling model...")
+      self.model.forward = torch.compile(self.model.forward)
 
   @classmethod
   def _from_pretrained(

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -16,6 +16,7 @@
 
 import os
 import tempfile
+import types
 
 from timesfm.timesfm_2p5.timesfm_2p5_torch import TimesFM_2p5_200M_torch
 from timesfm.timesfm_2p5.timesfm_2p5_flax import TimesFM_2p5_200M_flax
@@ -58,6 +59,33 @@ class TestModelLoading:
       forecasts = tfm3.model.forecast_naive(horizon=10, inputs=inputs)
       assert len(forecasts) == 1
       assert forecasts[0].shape == (10, 10)
+
+  def test_torch_compile_wraps_forward(self):
+    """Verifies that torch_compile=True compiles model.forward, not a no-op."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+      tfm = TimesFM_2p5_200M_torch(torch_compile=False)
+      tfm._save_pretrained(tmpdir)
+
+      tfm_compiled = TimesFM_2p5_200M_torch(torch_compile=True)
+      tfm_compiled.load_checkpoint(tmpdir)
+
+      # forward should be a compiled callable, not a plain bound method
+      assert not isinstance(tfm_compiled.model.forward, types.MethodType), (
+          "model.forward should be compiled after load_checkpoint with torch_compile=True"
+      )
+
+  def test_torch_no_compile_leaves_forward_unchanged(self):
+    """Verifies that torch_compile=False leaves model.forward as a plain method."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+      tfm = TimesFM_2p5_200M_torch(torch_compile=False)
+      tfm._save_pretrained(tmpdir)
+
+      tfm_no_compile = TimesFM_2p5_200M_torch(torch_compile=False)
+      tfm_no_compile.load_checkpoint(tmpdir)
+
+      assert isinstance(tfm_no_compile.model.forward, types.MethodType), (
+          "model.forward should remain a plain bound method when torch_compile=False"
+      )
 
   def test_flax_model_init_kwargs(self):
     """Verifies that Flax model wrapper constructor accepts arbitrary kwargs."""


### PR DESCRIPTION
Closes #457

`TimesFM_2p5_200M_torch_module.load_checkpoint` called `self = torch.compile(self)` inside the method body. That rebinds the local name `self` but doesn't mutate the object — the compiled version is immediately thrown away. Users passing `torch_compile=True` got no speedup at all.

The fix moves the compile call to the outer `TimesFM_2p5_200M_torch.load_checkpoint`, targeting `self.model.forward` directly:

```python
torch_compile = kwargs.pop("torch_compile", self.torch_compile)
self.model.load_checkpoint(model_file_path, **kwargs)
if torch_compile:
    self.model.forward = torch.compile(self.model.forward)
```

`nn.Module.__call__` dispatches through `self.forward`, so reassigning the instance attribute is enough for the compiled version to be used by the `decode()` path.

## Why it still helps despite graph breaks

`forward` does not trace into a single clean graph. Each transformer layer writes to its KV cache with a data-dependent slice:

```python
start = decode_cache.next_index[0]    # tensor value, needs an implicit .item()
decode_cache.key[:, start:end] = key  # transformer.py:279
```

Dynamo can't trace a slice whose index is a runtime tensor value, so it graph-breaks here — once per layer. `torch._dynamo.explain()` on the real decode call path (forward + a populated cache) shows **8 graphs / 7 breaks**.

The breaks land on cheap memory copies. The expensive work — the QKV/attention/MLP matmuls — sits inside the compiled subgraphs and gets fused and optimized normally. So compile still pays off, just not as much as a fully unbroken graph would.

Measured on A100 with `google/timesfm-2.5-200m-pytorch`, batch=64, context=512, horizon=128: **1.55x median speedup** (**111ms → 72ms**). Numerical diff vs uncompiled: max abs 7.2e-05 (TF32 rounding).

## Tests

Two new tests in `tests/test_model_loading.py` verify that `model.forward` is compiled after `load_checkpoint(torch_compile=True)` and left as a plain bound method when `torch_compile=False`.

## **Possible follow-up** (not in this PR)

The per-layer graph break could be removed by making the cache-write index non-data-dependent (e.g. `capture_scalar_outputs=True`, or an `index_copy`/`slice_scatter` with a precomputed index). That would unlock the remaining headroom but is a larger, separate change.
