### PR TITLE
fix(torch): apply quantile flip to autoregressive outputs in force_flip_invariance

### DIFF
--- a/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py
+++ b/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py
@@ -461,7 +461,10 @@ class TimesFM_2p5_200M_torch(
         flipped_pf_outputs = flip_quantile_fn(flipped_pf_outputs)
         to_cat = [flipped_pf_outputs[:, -1, ...]]
         if flipped_ar_outputs is not None:
-          to_cat.append(flipped_ar_outputs.reshape(batch_size, -1, self.model.q))
+          flipped_ar_outputs = flip_quantile_fn(
+            flipped_ar_outputs.reshape(batch_size, -1, self.model.q)
+          )
+          to_cat.append(flipped_ar_outputs)
         flipped_full_forecast = torch.cat(to_cat, dim=1)
         quantile_spreads = (quantile_spreads - flipped_quantile_spreads) / 2
         pf_outputs = (pf_outputs - flipped_pf_outputs) / 2

--- a/tests/test_force_flip_invariance.py
+++ b/tests/test_force_flip_invariance.py
@@ -1,0 +1,73 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for force_flip_invariance in the PyTorch TimesFM 2.5 model."""
+
+import numpy as np
+import torch
+
+from timesfm import configs
+from timesfm.timesfm_2p5.timesfm_2p5_torch import TimesFM_2p5_200M_torch
+
+
+def _flip_quantile(x):
+  # Keep the mean channel (index 0), reverse the nine quantile channels.
+  return torch.cat([x[..., :1], torch.flip(x[..., 1:], dims=(-1,))], dim=-1)
+
+
+class TestForceFlipInvariance:
+  """force_flip_invariance must hold over the whole horizon, not just prefill."""
+
+  def test_flip_invariance_holds_in_autoregressive_region(self):
+    # With force_flip_invariance the model is symmetrized so that
+    # forecast(-x) == -flip_quantile(forecast(x)) at every horizon step. The
+    # property is independent of the weights, so a random init is enough to
+    # check it. A missing quantile flip on the autoregressive branch breaks it
+    # past the first output patch (128 steps).
+    torch.manual_seed(0)
+    tfm = TimesFM_2p5_200M_torch(torch_compile=False)
+    tfm.model.eval()
+
+    # max_horizon 256 > output patch length 128 so the AR branch is exercised.
+    fc = configs.ForecastConfig(
+        max_context=256,
+        max_horizon=256,
+        force_flip_invariance=True,
+        use_continuous_quantile_head=False,
+        infer_is_positive=False,  # skip the nonneg clamp so the identity is exact
+        normalize_inputs=False,
+        fix_quantile_crossing=False,
+        return_backcast=False,
+    )
+    tfm.compile(fc)
+
+    rng = np.random.RandomState(0)
+    context = rng.standard_normal((1, 256)).astype(np.float32)  # mixed sign
+    masks = np.zeros((1, 256), dtype=bool)
+
+    with torch.no_grad():
+      _, forecast_pos = tfm.compiled_decode(256, context, masks)
+      _, forecast_neg = tfm.compiled_decode(256, -context, masks)
+
+    forecast_pos = torch.from_numpy(np.asarray(forecast_pos))
+    forecast_neg = torch.from_numpy(np.asarray(forecast_neg))
+    expected = -_flip_quantile(forecast_pos)
+
+    # The prefill region (first 128 steps) matched even before the fix; the AR
+    # region (128:256) is where the missing flip showed up.
+    ar_region = slice(128, 256)
+    torch.testing.assert_close(
+        forecast_neg[:, ar_region, :], expected[:, ar_region, :],
+        atol=1e-4, rtol=1e-4,
+    )


### PR DESCRIPTION
### What

`force_flip_invariance` reverses the quantile axis of the flipped forecast (`forecast(-x)`) before averaging it against `forecast(x)`. In the PyTorch model the prefill outputs and the quantile spreads get flipped, but the autoregressive branch was concatenated without the flip:

```python
flipped_pf_outputs = flip_quantile_fn(flipped_pf_outputs)        # flipped
...
if flipped_ar_outputs is not None:
    to_cat.append(flipped_ar_outputs.reshape(...))               # not flipped
```

The Flax implementation flips all three, including `flipped_ar_outputs` (`timesfm_2p5_flax.py`). This adds the missing flip to the torch path.

### Impact

For horizons longer than one output patch (128 steps), the autoregressive region's quantile channels are misaligned in the flip-invariance average, so the prediction intervals there are wrong. The mean and median are fixed points of the quantile flip, so the point/median forecast is unaffected, which is likely why it went unnoticed. `force_flip_invariance` is on by default, and for long horizons the continuous quantile head is disallowed, so the affected bands are what gets returned.

### Test

Adds `tests/test_force_flip_invariance.py`. With `force_flip_invariance` the model satisfies `forecast(-x) == -flip_quantile(forecast(x))` at every horizon step, independent of the weights, so a random init is enough to check it. The test asserts this identity across the autoregressive region (steps 128:256). It fails before the fix (about 80% of the band values off) and passes after. Flip-invariance test passes; `ruff check` clean.

### Note — supersedes #462

This replaces #462, which GitHub auto-closed after I botched a force-push: I amended the commit from a shallow clone, which dropped its parent and briefly turned the diff into the whole repo. Sorry for the noise — this PR is the same fix on a clean commit off `master`.

Addressing @rajatsen91's review on #462:

- The AR flip is now applied **after** `flipped_ar_outputs.reshape(batch_size, -1, self.model.q)`, as you suggested. I checked the shape: `ar_renormed_outputs` is `(batch, num_decode_steps, o, q)` (each AR step is `new_renormed_output[:, -1, ...]` stacked on dim 1), so `q` is already the innermost axis and flip-before vs flip-after is bit-identical here. Doing it after the reshape makes the quantile axis unambiguous at the flip site.
- Agreed on the `quantile_spreads`/continuous-quantile-head line — that block only reads `full_forecast` at the median index (5) and rebuilds the other bands from `quantile_spreads`, so the AR-region flip does not affect it.
