### PR TITLE
docs(examples): update global-temperature report to TimesFM 2.5

### DIFF
--- a/timesfm-forecasting/examples/global-temperature/README.md
+++ b/timesfm-forecasting/examples/global-temperature/README.md
@@ -1,14 +1,14 @@
 # TimesFM Forecast Report: Global Temperature Anomaly (2025)
 
-**Model:** TimesFM 1.0 (200M) PyTorch  
-**Generated:** 2026-02-21  
+**Model:** TimesFM 2.5 (200M) PyTorch
+**Generated:** 2026-08-18
 **Source:** NOAA GISTEMP Global Land-Ocean Temperature Index
 
 ---
 
 ## Executive Summary
 
-TimesFM forecasts a mean temperature anomaly of **1.19°C** for 2025, slightly below the 2024 average of 1.25°C. The model predicts continued elevated temperatures with a peak of 1.30°C in March 2025 and a minimum of 1.06°C in December 2025.
+TimesFM forecasts a mean temperature anomaly of **1.24°C** for 2025, essentially level with the 2024 average of 1.25°C. The model predicts a peak of 1.29°C in March 2025 and a shallow minimum of 1.20°C in May, with a second, smaller peak in September.
 
 ---
 
@@ -40,54 +40,58 @@ TimesFM forecasts a mean temperature anomaly of **1.19°C** for 2025, slightly b
 
 ## Raw Forecast Output
 
-### Point Forecast and Confidence Intervals
+### Point Forecast and Prediction Intervals
 
-| Month | Point | 80% CI | 90% CI |
+Quantile columns are `[mean, q10, q20, ..., q90]`, so the 60% interval is `q20`-`q80` and the 80% interval is `q10`-`q90`.
+
+| Month | Point | 60% PI | 80% PI |
 |-------|-------|--------|--------|
-| 2025-01 | 1.259 | [1.141, 1.297] | [1.248, 1.324] |
-| 2025-02 | 1.286 | [1.141, 1.340] | [1.277, 1.375] |
-| 2025-03 | 1.295 | [1.127, 1.355] | [1.287, 1.404] |
-| 2025-04 | 1.221 | [1.035, 1.290] | [1.208, 1.331] |
-| 2025-05 | 1.170 | [0.969, 1.239] | [1.153, 1.289] |
-| 2025-06 | 1.146 | [0.942, 1.218] | [1.128, 1.270] |
-| 2025-07 | 1.170 | [0.950, 1.248] | [1.151, 1.300] |
-| 2025-08 | 1.203 | [0.971, 1.284] | [1.186, 1.341] |
-| 2025-09 | 1.191 | [0.959, 1.283] | [1.178, 1.335] |
-| 2025-10 | 1.149 | [0.908, 1.240] | [1.126, 1.287] |
-| 2025-11 | 1.080 | [0.836, 1.176] | [1.062, 1.228] |
-| 2025-12 | 1.061 | [0.802, 1.153] | [1.037, 1.217] |
+| 2025-01 | 1.222 | [1.161, 1.293] | [1.123, 1.340] |
+| 2025-02 | 1.256 | [1.189, 1.336] | [1.148, 1.388] |
+| 2025-03 | 1.286 | [1.214, 1.373] | [1.169, 1.427] |
+| 2025-04 | 1.240 | [1.169, 1.324] | [1.119, 1.381] |
+| 2025-05 | 1.203 | [1.128, 1.289] | [1.078, 1.347] |
+| 2025-06 | 1.210 | [1.135, 1.294] | [1.081, 1.353] |
+| 2025-07 | 1.225 | [1.147, 1.311] | [1.092, 1.373] |
+| 2025-08 | 1.242 | [1.160, 1.330] | [1.104, 1.395] |
+| 2025-09 | 1.270 | [1.187, 1.358] | [1.124, 1.425] |
+| 2025-10 | 1.250 | [1.163, 1.338] | [1.096, 1.410] |
+| 2025-11 | 1.214 | [1.122, 1.309] | [1.055, 1.380] |
+| 2025-12 | 1.203 | [1.111, 1.291] | [1.041, 1.370] |
 
 ### JSON Output
 
 ```json
 {
-  "model": "TimesFM 1.0 (200M) PyTorch",
+  "model": "TimesFM 2.5 (200M) PyTorch",
   "input": {
     "source": "NOAA GISTEMP Global Temperature Anomaly",
     "n_observations": 36,
     "date_range": "2022-01 to 2024-12",
-    "mean_anomaly_c": 1.089
+    "mean_anomaly_c": 1.09
   },
   "forecast": {
     "horizon": 12,
     "dates": ["2025-01", "2025-02", "2025-03", "2025-04", "2025-05", "2025-06",
               "2025-07", "2025-08", "2025-09", "2025-10", "2025-11", "2025-12"],
-    "point": [1.259, 1.286, 1.295, 1.221, 1.170, 1.146, 1.170, 1.203, 1.191, 1.149, 1.080, 1.061]
+    "point": [1.222, 1.256, 1.286, 1.240, 1.203, 1.210, 1.225, 1.242, 1.270, 1.250, 1.214, 1.203]
   },
   "summary": {
-    "forecast_mean_c": 1.186,
-    "forecast_max_c": 1.295,
-    "forecast_min_c": 1.061,
-    "vs_last_year_mean": -0.067
+    "forecast_mean_c": 1.235,
+    "forecast_max_c": 1.286,
+    "forecast_min_c": 1.203,
+    "vs_last_year_mean": -0.017
   }
 }
 ```
+
+The full file, including all ten quantile columns, is at `output/forecast_output.json`.
 
 ---
 
 ## Visualization
 
-![Temperature Anomaly Forecast](forecast_visualization.png)
+![Temperature Anomaly Forecast](output/forecast_visualization.png)
 
 ---
 
@@ -95,24 +99,24 @@ TimesFM forecasts a mean temperature anomaly of **1.19°C** for 2025, slightly b
 
 ### Key Observations
 
-1. **Slight cooling trend expected**: The model forecasts a mean anomaly 0.07°C below 2024 levels, suggesting a potential stabilization after the record-breaking temperatures of 2023-2024.
+1. **Plateau rather than continued rise**: the forecast mean sits 0.02°C below the 2024 mean. After the sharp 2022→2024 climb of +0.37°C, the model extrapolates a level year rather than either a further jump or a fall back.
 
-2. **Seasonal pattern preserved**: The forecast shows the expected seasonal variation with higher anomalies in late winter (Feb-Mar) and lower in late fall (Nov-Dec).
+2. **Seasonal pattern preserved**: the forecast keeps the late-winter high (March) and adds a secondary September peak, both of which are present in the 2023 and 2024 observations.
 
-3. **Widening uncertainty**: The 90% CI expands from ±0.04°C in January to ±0.08°C in December, reflecting typical forecast uncertainty growth over time.
+3. **Widening uncertainty**: the 80% interval grows from ±0.11°C in January to ±0.16°C in December (width 0.217 → 0.329), the usual growth of forecast uncertainty with horizon.
 
-4. **Peak temperature**: March 2025 is predicted to have the highest anomaly at 1.30°C, potentially approaching the September 2023 record of 1.47°C.
+4. **Peak temperature**: March 2025 is the highest month at 1.29°C, still well below the September 2023 record of 1.47°C in the input data.
 
 ### Limitations
 
 - TimesFM is a zero-shot forecaster without physical climate model constraints
-- The 36-month training window may not capture multi-decadal climate trends
+- The 36-month context is short and cannot capture multi-decadal climate trends
 - El Niño/La Niña cycles are not explicitly modeled
 
 ### Recommendations
 
 - Use this forecast as a baseline comparison for physics-based climate models
-- Update forecast quarterly as new observations become available
+- Update the forecast as new observations become available
 - Consider ensemble approaches combining TimesFM with other methods
 
 ---
@@ -124,12 +128,18 @@ TimesFM forecasts a mean temperature anomaly of **1.19°C** for 2025, slightly b
 | File | Description |
 |------|-------------|
 | `temperature_anomaly.csv` | Input data (36 months) |
-| `forecast_output.csv` | Point forecast with quantiles |
-| `forecast_output.json` | Machine-readable forecast |
-| `forecast_visualization.png` | Fan chart visualization |
 | `run_forecast.py` | Forecasting script |
-| `visualize_forecast.py` | Visualization script |
-| `run_example.sh` | One-click runner |
+| `visualize_forecast.py` | Fan chart visualization |
+| `generate_animation_data.py` | Incremental forecasts for the animation |
+| `generate_gif.py` | Animated GIF from the animation data |
+| `generate_html.py` | Self-contained interactive HTML |
+| `run_example.sh` | One-click runner (preflight, forecast, visualization) |
+| `output/forecast_output.csv` | Point forecast with all quantiles |
+| `output/forecast_output.json` | Machine-readable forecast |
+| `output/forecast_visualization.png` | Fan chart |
+| `output/animation_data.json` | Per-step forecasts driving the animation |
+| `output/forecast_animation.gif` | Animated forecast |
+| `output/interactive_forecast.html` | Interactive forecast |
 
 ### How to Reproduce
 
@@ -138,41 +148,53 @@ TimesFM forecasts a mean temperature anomaly of **1.19°C** for 2025, slightly b
 uv pip install "timesfm[torch]" matplotlib pandas numpy
 
 # Run the complete example
-cd scientific-skills/timesfm-forecasting/examples/global-temperature
+cd timesfm-forecasting/examples/global-temperature
 ./run_example.sh
 ```
+
+The model weights (~800 MB) download from Hugging Face on first use and cache in
+`~/.cache/huggingface/`. The forecast itself runs in seconds on CPU.
 
 ---
 
 ## Technical Notes
 
-### API Discovery
+### API
 
-The TimesFM PyTorch API differs from the GitHub README documentation:
+TimesFM 2.5 loads through `from_pretrained` and must be compiled with a `ForecastConfig`
+before `forecast()` is called:
 
-**Documented (GitHub README):**
 ```python
-model = timesfm.TimesFm(
-    context_len=512,
-    horizon_len=128,
-    backend="gpu",
+import timesfm
+
+model = timesfm.TimesFM_2p5_200M_torch.from_pretrained(
+    "google/timesfm-2.5-200m-pytorch",
+    torch_compile=False,
 )
-model.load_from_google_repo("google/timesfm-2.5-200m-pytorch")
+model.compile(timesfm.ForecastConfig(
+    max_context=512,
+    max_horizon=12,
+    normalize_inputs=True,
+    use_continuous_quantile_head=True,
+    fix_quantile_crossing=True,
+))
+
+point_forecast, quantile_forecast = model.forecast(horizon=12, inputs=[values])
 ```
 
-**Actual Working API:**
-```python
-hparams = timesfm.TimesFmHparams(horizon_len=12)
-checkpoint = timesfm.TimesFmCheckpoint(
-    huggingface_repo_id="google/timesfm-1.0-200m-pytorch"
-)
-model = timesfm.TimesFm(hparams=hparams, checkpoint=checkpoint)
-```
+Two differences from the archived 1.0/2.0 API are worth noting when adapting older code:
 
-### TimesFM 2.5 PyTorch Issue
+- `TimesFmHparams`, `TimesFmCheckpoint` and `TimesFm` no longer exist, and 2.5 has no
+  frequency indicator, so `freq=[0]` is gone.
+- The quantile array is `[mean, q10, q20, ..., q90]`. Column 0 is the **mean**, not q10;
+  q10 is at index 1 and q90 at index 9, and the median at index 5 equals `point_forecast`.
 
-The `google/timesfm-2.5-200m-pytorch` checkpoint downloads as `model.safetensors`, but the TimesFM loader expects `torch_model.ckpt`. This causes a `FileNotFoundError` at model load time. Using TimesFM 1.0 PyTorch resolves this issue.
+### Checkpoint format
+
+The `google/timesfm-2.5-200m-pytorch` checkpoint ships as `model.safetensors` and loads
+directly. Older notes describing a `torch_model.ckpt` requirement apply to the 1.0/2.0
+loaders only.
 
 ---
 
-*Report generated by TimesFM Forecasting Skill (claude-scientific-skills)*
+*Report generated by the TimesFM Forecasting Skill*


### PR DESCRIPTION
Docs follow-up to #465 and #466, and the last piece of the 2.5 migration for this example. Independent of both; no code changes.

This example's report still describes a TimesFM 1.0 run, so it contradicts the outputs committed next to it. 6ed1d8a regenerated those with 2.5 but left the report untouched.

## What was wrong

**The numbers disagreed with `output/forecast_output.json`.**

|                    | README said | `forecast_output.json` says |
| ------------------ | ----------- | --------------------------- |
| forecast mean      | 1.19 C      | 1.235 C                     |
| minimum            | 1.06 C, Dec | 1.203 C, May                |
| vs 2024            | -0.067      | -0.017                      |

**The interval table was mislabelled.** It carried an "80% CI" and a "90% CI" column, and the "90%" was consistently the narrower of the two, e.g. 2025-01 showed 80% as [1.141, 1.297] around a 90% of [1.248, 1.324]. The script prints the 60% (q20-q80) and 80% (q10-q90) intervals; the table is now labelled that way.

**The Technical Notes were actively misleading.** An "Actual Working API" block documented `TimesFmHparams` / `TimesFmCheckpoint` / `TimesFm`, which 2.5 removed, and a note stated that the 2.5 PyTorch checkpoint fails to load with a `FileNotFoundError` because the loader expects `torch_model.ckpt`, recommending 1.0 instead. That is no longer true: the checkpoint ships as `model.safetensors` and loads directly. This note is plausibly why the scripts in #465 and #466 stayed on the v1 API.

**Two references were broken.** The embedded image pointed at `forecast_visualization.png`, but the file lives at `output/forecast_visualization.png`, so it did not render on GitHub. The reproduce step began `cd scientific-skills/timesfm-forecasting/...`, a directory that does not exist in this repo.

## What this changes

- Every number rebuilt from `output/forecast_output.json`. I verified each table row, the JSON block and each narrative claim against that file programmatically rather than by eye.
- Intervals relabelled 60% / 80% to match what `run_forecast.py` prints.
- Technical Notes replaced with the current `from_pretrained` + `ForecastConfig` usage, plus a short note that the quantile array is `[mean, q10, ..., q90]` so column 0 is the mean.
- Image path and reproduce path fixed, and the file table extended to cover the animation and HTML artifacts that were already committed but undocumented.

The findings section is rewritten to follow the corrected numbers: the forecast is a plateau against 2024 (-0.02 C), not the 0.07 C cooling the old text described.

No input data changed and no outputs were regenerated, so this is documentation only.

Refs #423
