### PR TITLE
fix: stop forecast() from mutating the caller's input list

### DIFF
--- a/src/timesfm/timesfm_2p5/timesfm_2p5_base.py
+++ b/src/timesfm/timesfm_2p5/timesfm_2p5_base.py
@@ -165,7 +165,9 @@ class TimesFM_2p5:
     context = self.forecast_config.max_context
     num_inputs = len(inputs)
     if (w := num_inputs % self.global_batch_size) != 0:
-      inputs += [np.array([0.0] * 3)] * (self.global_batch_size - w)
+      # Copy rather than extend in place: `inputs += ...` would append the
+      # padding to the caller's list.
+      inputs = list(inputs) + [np.array([0.0] * 3)] * (self.global_batch_size - w)
 
     output_points = []
     output_quantiles = []

--- a/tests/test_forecast_inputs.py
+++ b/tests/test_forecast_inputs.py
@@ -1,0 +1,91 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for input handling in ``TimesFM_2p5.forecast``.
+
+``forecast`` pads the batch when the number of inputs is not a multiple of
+the global batch size.  That padding must not be visible to the caller: a
+caller that reuses its input list across calls would otherwise accumulate
+padding entries and silently receive forecasts for them.
+
+These tests drive the base class through a stub decode function so they
+run without model weights.
+"""
+
+import numpy as np
+
+from timesfm import configs
+from timesfm.timesfm_2p5 import timesfm_2p5_base
+
+
+class _StubTimesFM(timesfm_2p5_base.TimesFM_2p5):
+  """Minimal concrete model whose decode step returns zeros."""
+
+  def __init__(self, global_batch_size: int, horizon: int):
+    self.global_batch_size = global_batch_size
+    self.forecast_config = configs.ForecastConfig(
+        max_context=64, max_horizon=horizon
+    )
+    self.calls = 0
+
+    def _decode(h, values, masks):
+      self.calls += 1
+      b = len(values)
+      return np.zeros((b, h)), np.zeros((b, h, 10))
+
+    self.compiled_decode = _decode
+
+
+def _series(n: int = 40) -> np.ndarray:
+  return np.linspace(0.0, 1.0, n, dtype=np.float32)
+
+
+class TestForecastDoesNotMutateInputs:
+
+  def test_input_list_length_unchanged_when_padding_needed(self):
+    model = _StubTimesFM(global_batch_size=4, horizon=8)
+    inputs = [_series() for _ in range(3)]  # 3 % 4 != 0, so padding is added
+    model.forecast(horizon=8, inputs=inputs)
+    assert len(inputs) == 3
+
+  def test_input_elements_unchanged(self):
+    model = _StubTimesFM(global_batch_size=4, horizon=8)
+    original = [_series() for _ in range(3)]
+    inputs = list(original)
+    model.forecast(horizon=8, inputs=inputs)
+    assert [len(x) for x in inputs] == [len(x) for x in original]
+    for a, b in zip(inputs, original):
+      np.testing.assert_array_equal(a, b)
+
+  def test_no_mutation_when_batch_divides_evenly(self):
+    model = _StubTimesFM(global_batch_size=2, horizon=8)
+    inputs = [_series() for _ in range(4)]
+    model.forecast(horizon=8, inputs=inputs)
+    assert len(inputs) == 4
+
+  def test_repeated_calls_return_one_forecast_per_input(self):
+    """Reusing the same list must not grow the returned batch."""
+    model = _StubTimesFM(global_batch_size=4, horizon=8)
+    inputs = [_series() for _ in range(3)]
+    for _ in range(3):
+      point, quantiles = model.forecast(horizon=8, inputs=inputs)
+      assert point.shape == (3, 8)
+      assert quantiles.shape == (3, 8, 10)
+      assert len(inputs) == 3
+
+  def test_accepts_a_tuple_of_inputs(self):
+    """A non-list sequence must not raise when padding is required."""
+    model = _StubTimesFM(global_batch_size=4, horizon=8)
+    point, _ = model.forecast(horizon=8, inputs=tuple(_series() for _ in range(3)))
+    assert point.shape == (3, 8)


### PR DESCRIPTION
`TimesFM_2p5.forecast` mutates the list the caller passes in. Unrelated to #465/#466/#467, which only touch examples; this is in the main inference entry point.

## The bug

When the batch needs padding, `src/timesfm/timesfm_2p5/timesfm_2p5_base.py:168` does:

```python
inputs += [np.array([0.0] * 3)] * (self.global_batch_size - w)
```

`+=` on a list is an in-place `extend`, so the padding is appended to the caller's own list:

```python
>>> mine = [series, series, series]        # global_batch_size = 4
>>> len(mine)
3
>>> model.forecast(horizon=8, inputs=mine)
>>> len(mine)
4
>>> len(mine[-1])
3
```

The first call still returns the right answer, because the output is trimmed to `num_inputs`. The problem is the second one. `num_inputs` is recomputed from the now-longer list, so the caller gets back **a fourth forecast for a length-3 padding array, presented as a real result**, and the list grows again on every subsequent call. Silently wrong output rather than an exception.

I hit this for real while backtesting: 456 context windows became 464, with eight length-3 zero arrays appended, and the next `np.array(ctxs)` raised `inhomogeneous shape`. That failure was loud only because I happened to rebuild an array from the list afterwards — code that just calls `forecast` in a loop gets no signal at all.

## The fix

Build the padded batch as a copy:

```python
inputs = list(inputs) + [np.array([0.0] * 3)] * (self.global_batch_size - w)
```

One line, no behaviour change for a single call. As a side effect any sequence now works, where a tuple previously raised `TypeError: can only concatenate tuple (not "list") to tuple` on the `+=`.

## Tests

`tests/test_forecast_inputs.py` covers the padded path, the evenly-divided path (no padding, no mutation), repeated calls on one list, and tuple input. They drive the base class through a stub decode function, so they run without model weights and add no network dependency to CI.

Verified they actually catch the bug: **4 of the 5 fail on master** and all pass with the fix. The one that passes either way is the evenly-divided case, which never enters the padding branch.

```
$ pytest tests/ -q --ignore=tests/test_model_loading.py
64 passed
```

`test_model_loading.py` is excluded only because it needs the `flax` extra, which is unrelated to this change.
