### PR TITLE
fix(xreg): handle empty dimensions in padded JAX arrays

### DIFF
--- a/src/timesfm/utils/xreg_lib.py
+++ b/src/timesfm/utils/xreg_lib.py
@@ -44,14 +44,19 @@ def _repeat(elements: Iterable[Any], counts: Iterable[int]) -> np.ndarray:
 
 
 def _to_padded_jax_array(x: np.ndarray) -> jax.Array:
+  def padding_size(size: int) -> int:
+    if size == 0:
+      return 0
+    return 2 ** math.ceil(math.log2(size)) - size
+
   if x.ndim == 1:
     (i,) = x.shape
-    di = 2 ** math.ceil(math.log2(i)) - i
+    di = padding_size(i)
     return jnp.pad(x, ((0, di),), mode="constant", constant_values=0.0)
   elif x.ndim == 2:
     i, j = x.shape
-    di = 2 ** math.ceil(math.log2(i)) - i
-    dj = 2 ** math.ceil(math.log2(j)) - j
+    di = padding_size(i)
+    dj = padding_size(j)
     return jnp.pad(x, ((0, di), (0, dj)), mode="constant", constant_values=0.0)
   else:
     raise ValueError(f"Unsupported array shape: {x.shape}")

--- a/tests/test_xreg_lib.py
+++ b/tests/test_xreg_lib.py
@@ -1,0 +1,65 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the XReg helpers."""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("jax")
+pytest.importorskip("sklearn")
+
+from timesfm.utils import xreg_lib
+
+
+@pytest.mark.parametrize(
+  ("shape", "expected_shape"),
+  [
+    ((0,), (0,)),
+    ((3, 0), (4, 0)),
+    ((0, 3), (0, 4)),
+  ],
+)
+def test_to_padded_jax_array_preserves_empty_dimensions(shape, expected_shape):
+  padded = xreg_lib._to_padded_jax_array(np.empty(shape))
+
+  assert padded.shape == expected_shape
+
+
+def test_to_padded_jax_array_still_pads_nonempty_dimensions():
+  values = np.arange(6).reshape(3, 2)
+
+  padded = xreg_lib._to_padded_jax_array(values)
+
+  assert padded.shape == (4, 2)
+  np.testing.assert_array_equal(np.asarray(padded)[:3], values)
+  np.testing.assert_array_equal(np.asarray(padded)[3], np.zeros(2))
+
+
+def test_fit_handles_single_category_without_intercept():
+  model = xreg_lib.BatchedInContextXRegLinear(
+    targets=[[1.0, 2.0, 3.0]],
+    train_lens=[3],
+    test_lens=[2],
+    train_dynamic_categorical_covariates={"kind": [["same"] * 3]},
+    test_dynamic_categorical_covariates={"kind": [["same"] * 2]},
+  )
+
+  outputs = model.fit(
+    use_intercept=False,
+    assert_covariates=True,
+    assert_covariate_shapes=True,
+  )
+
+  np.testing.assert_array_equal(outputs, np.zeros((1, 2)))

--- a/v1/src/timesfm/xreg_lib.py
+++ b/v1/src/timesfm/xreg_lib.py
@@ -40,14 +40,19 @@ def _repeat(elements: Iterable[Any], counts: Iterable[int]) -> np.ndarray:
 
 
 def _to_padded_jax_array(x: np.ndarray) -> jax.Array:
+  def padding_size(size: int) -> int:
+    if size == 0:
+      return 0
+    return 2**math.ceil(math.log2(size)) - size
+
   if x.ndim == 1:
     (i,) = x.shape
-    di = 2**math.ceil(math.log2(i)) - i
+    di = padding_size(i)
     return jnp.pad(x, ((0, di),), mode="constant", constant_values=0.0)
   elif x.ndim == 2:
     i, j = x.shape
-    di = 2**math.ceil(math.log2(i)) - i
-    dj = 2**math.ceil(math.log2(j)) - j
+    di = padding_size(i)
+    dj = padding_size(j)
     return jnp.pad(x, ((0, di), (0, dj)), mode="constant", constant_values=0.0)
   else:
     raise ValueError(f"Unsupported array shape: {x.shape}")


### PR DESCRIPTION
## Summary

- preserve zero-length axes when padding XReg arrays to power-of-two dimensions
- keep the current and archived v1 XReg implementations behaviorally aligned
- add coverage for empty 1D/2D arrays and the single-category, no-intercept regression path

## Root cause

`_to_padded_jax_array` called `math.log2(0)` for arrays with an empty dimension. A valid way to reach this state is a single-category feature encoded with `drop="first"` while the intercept is disabled, which produces an `(n, 0)` design matrix.

The padding helper now treats a zero-length dimension as requiring zero padding while continuing to power-of-two pad every non-empty dimension.

## Testing

- `PYTHONPATH=src python -m pytest tests -q` — 68 passed
- `PYTHONPATH=src python -m pytest tests/test_xreg_lib.py -q` — 5 passed
- `python -m ruff check tests/test_xreg_lib.py`
- `git diff --check`

Fixes #197