### PR TITLE
Fix RMSNorm scale zero-initialization

### DIFF
--- a/src/timesfm/flax/normalization.py
+++ b/src/timesfm/flax/normalization.py
@@ -39,7 +39,7 @@ class RMSNorm(nnx.Module):
     rngs=nnx.Rngs(42),
   ):
     del rngs
-    self.scale = nnx.Param(jnp.zeros(shape=(num_features,)))
+    self.scale = nnx.Param(jnp.ones(shape=(num_features,)))
     self.num_features = num_features
     self.epsilon = epsilon
 


### PR DESCRIPTION
`RMSNorm.__init__` in `src/timesfm/flax/normalization.py` initializes
`self.scale` with `jnp.zeros` instead of `jnp.ones`:

    self.scale = nnx.Param(jnp.zeros(shape=(num_features,)))

Since `__call__` does `normed_inputs *= self.scale`, this makes
RMSNorm output all zeros on a fresh forward pass, before any
checkpoint load overwrites the parameter.

`LayerNorm` in the same file correctly initializes its scale with
`jnp.ones` — this looks like a copy-paste bug between the two classes.

Currently masked in inference when checkpoints are always loaded
before a forward pass, but affects:
- standalone instantiation of RMSNorm (e.g. in tests)
- any future from-scratch training / fine-tuning of the flax backend

Fix: `jnp.zeros` → `jnp.ones`, matching `LayerNorm`'s pattern.