### PR TITLE
docs: quote extras specifiers in install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ TimesFM 2.5:
 
 ```shell
 # Install TimesFM with PyTorch
-pip install timesfm[torch]
+pip install "timesfm[torch]"
 ```
 
 #### Local Install
@@ -142,7 +142,7 @@ pip install timesfm[torch]
     source .venv/bin/activate
 
      # Install the package in editable mode with torch
-    uv pip install -e .[torch]
+    uv pip install -e ".[torch]"
     ```
 
 --------------------------------------------------------------------------------

--- a/timesfm-forecasting/SKILL.md
+++ b/timesfm-forecasting/SKILL.md
@@ -42,7 +42,7 @@ Use this skill when:
 - You have time series of **any length** (the model handles 1–16,384 context points)
 - You need to **batch-forecast** hundreds or thousands of series efficiently
 - You want a **foundation model** approach instead of hand-tuning ARIMA/ETS parameters
-- You need **covariate forecasting** with exogenous variables (price, promotions, holidays, day-of-week effects) → use `forecast_with_covariates()` (TimesFM 2.5 + `pip install timesfm[xreg]`)
+- You need **covariate forecasting** with exogenous variables (price, promotions, holidays, day-of-week effects) → use `forecast_with_covariates()` (TimesFM 2.5 + `pip install "timesfm[xreg]"`)
 
 
 Do **not** use this skill when:
@@ -150,13 +150,13 @@ python scripts/check_system.py
 
 ```bash
 # Using uv (fast)
-uv pip install timesfm[torch]
+uv pip install "timesfm[torch]"
 
 # Or using pip
-pip install timesfm[torch]
+pip install "timesfm[torch]"
 
 # For JAX/Flax backend (faster on TPU/GPU)
-uv pip install timesfm[flax]
+uv pip install "timesfm[flax]"
 ```
 
 ### Step 3: Install PyTorch for Your Hardware
@@ -200,7 +200,7 @@ point, quantiles = model.forecast(horizon=24, inputs=[
 ### Forecast with Covariates (XReg)
 
 TimesFM 2.5+ supports exogenous variables through `forecast_with_covariates()`.
-Requires `pip install timesfm[xreg]`.
+Requires `pip install "timesfm[xreg]"`.
 
 ```python
 point, quantiles = model.forecast_with_covariates(

--- a/timesfm-forecasting/examples/covariates-forecasting/demo_covariates.py
+++ b/timesfm-forecasting/examples/covariates-forecasting/demo_covariates.py
@@ -4,7 +4,7 @@ TimesFM Covariates (XReg) Example
 
 Demonstrates the TimesFM covariate API using synthetic retail sales data.
 TimesFM 1.0 does NOT support forecast_with_covariates(); that requires
-TimesFM 2.5 + `pip install timesfm[xreg]`.
+TimesFM 2.5 + `pip install "timesfm[xreg]"`.
 
 This script:
   1. Generates synthetic 3-store weekly retail data (24-week context, 12-week horizon)
@@ -408,7 +408,7 @@ def demonstrate_api() -> None:
     print("=" * 70)
     print("""
 # Installation
-pip install timesfm[xreg]
+pip install "timesfm[xreg]"
 
 import timesfm
 hparams   = timesfm.TimesFmHparams(backend="cpu", per_core_batch_size=32, horizon_len=12)

--- a/timesfm-forecasting/references/system_requirements.md
+++ b/timesfm-forecasting/references/system_requirements.md
@@ -172,7 +172,7 @@ Works on any CPU with sufficient RAM. Expect 5–20× slower than GPU.
 
 | Package | Purpose | Install |
 | ------- | ------- | ------- |
-| jax | Flax backend | `pip install jax[cuda]` |
+| jax | Flax backend | `pip install "jax[cuda]"` |
 | flax | Flax backend | `pip install flax` |
 | scikit-learn | XReg covariates | `pip install scikit-learn` |
 


### PR DESCRIPTION
The install commands in `README.md` and three files under `timesfm-forecasting/` fail in zsh, which is the default shell on macOS.

zsh treats `[...]` as a glob character class and, unlike bash, errors when a pattern matches nothing:
```
$ pip install timesfm[torch]
zsh: no matches found: timesfm[torch]
```
Worse, when the pattern does match a file, zsh silently rewrites the argument instead of failing:
```
$ touch timesfmt
$ pip install timesfm[torch]     # -> pip tries to install timesfmt
```

Wrapping the specifier in double quotes fixes it, and works in sh, bash, zsh, fish and PowerShell.

The repo already does this in `.github/workflows/main.yml:25`.

Left `v1/` untouched since it's archived.