### PR TITLE
fix(timesfm3): keep past-future covariate windows aligned when the context is truncated

### DIFF
--- a/src/timesfm3/timesfm3_forecaster.py
+++ b/src/timesfm3/timesfm3_forecaster.py
@@ -151,9 +151,7 @@ def linear_interpolation(arr: np.ndarray) -> np.ndarray:
       non_nan_indices = valid_mask.nonzero()[0]
       non_nan_values = row[valid_mask]
       try:
-        row[nan_mask[r]] = np.interp(
-          nan_indices, non_nan_indices, non_nan_values
-        )
+        row[nan_mask[r]] = np.interp(nan_indices, non_nan_indices, non_nan_values)
       except ValueError:
         if non_nan_values.size > 0:
           mu = np.nanmean(row)
@@ -484,9 +482,7 @@ class TimesFM3Forecaster:
       * self.config.output_patch_length
     )
     num_original_ts = len(contexts)
-    original_ts_ids = (
-      list(ts_ids) if ts_ids is not None else [None] * num_original_ts
-    )
+    original_ts_ids = list(ts_ids) if ts_ids is not None else [None] * num_original_ts
 
     if len(contexts) == 0:
       return
@@ -509,17 +505,9 @@ class TimesFM3Forecaster:
     for idx, ctx in enumerate(contexts):
       target_clean = np.atleast_2d(np.array(ctx, dtype=np.float32))
       po = po_cov_list[idx]
-      po_arr = (
-        np.atleast_2d(np.array(po, dtype=np.float32))
-        if po is not None
-        else None
-      )
+      po_arr = np.atleast_2d(np.array(po, dtype=np.float32)) if po is not None else None
       pf = pf_cov_list[idx]
-      pf_arr = (
-        np.atleast_2d(np.array(pf, dtype=np.float32))
-        if pf is not None
-        else None
-      )
+      pf_arr = np.atleast_2d(np.array(pf, dtype=np.float32)) if pf is not None else None
 
       isnan = np.isnan(target_clean).all(axis=0)
       if isnan.all():
@@ -691,20 +679,27 @@ class TimesFM3Forecaster:
 
       po_torch = None
       if any(po is not None for po in batched_po):
-        po_arrs = [
-          po if po is not None else np.zeros_like(batched_tgt[j])
-          for j, po in enumerate(batched_po)
-        ]
+        # A query without covariates in a batch where others have them gets
+        # a zero placeholder shaped like the real covariate arrays (channel
+        # count and width), not like the target: the covariate channel count
+        # need not equal the number of target variates, and np.stack needs
+        # every entry to have the same shape.
+        po_ref = next(po for po in batched_po if po is not None)
+        po_arrs = [po if po is not None else np.zeros_like(po_ref) for po in batched_po]
         po_torch = torch.from_numpy(np.stack(po_arrs, axis=0)).to(
           self.device, dtype=torch.float32
         )
 
       pf_torch = None
       if any(pf is not None for pf in batched_pf):
-        pf_arrs = [
-          pf if pf is not None else np.zeros_like(batched_tgt[j])
-          for j, pf in enumerate(batched_pf)
-        ]
+        # Same for past-future covariates. decode infers the horizon from
+        # the covariate width (pf.shape[-1] - context) and slices the future
+        # part, so the placeholder must match the real arrays' width as well
+        # as their channel count. Real arrays in one batch already share both:
+        # their context is the batch context and their future part is the
+        # requested horizon.
+        pf_ref = next(pf for pf in batched_pf if pf is not None)
+        pf_arrs = [pf if pf is not None else np.zeros_like(pf_ref) for pf in batched_pf]
         pf_torch = torch.from_numpy(np.stack(pf_arrs, axis=0)).to(
           self.device, dtype=torch.float32
         )

--- a/src/timesfm3/timesfm3_forecaster.py
+++ b/src/timesfm3/timesfm3_forecaster.py
@@ -230,8 +230,14 @@ class _Query:
       if past_only_covariates is not None:
         past_only_covariates = past_only_covariates[:, -context_len:]
       if past_future_covariates is not None:
+        # Keep the covariate window aligned with the target window: the
+        # future part of `past_future_covariates` may be shorter than
+        # `self.horizon` (the patch-rounded horizon) when padding_mode is
+        # "none", so slice by the covariate's own future length rather than
+        # by `self.horizon`.
+        future_len = past_future_covariates.shape[-1] - self.context_length
         past_future_covariates = past_future_covariates[
-          :, -(context_len + self.horizon) :
+          :, -(context_len + future_len) :
         ]
     elif self.context_length < context_len:
       pad_len = context_len - self.context_length
@@ -482,7 +488,7 @@ class TimesFM3Forecaster:
       list(ts_ids) if ts_ids is not None else [None] * num_original_ts
     )
 
-    if not contexts:
+    if len(contexts) == 0:
       return
 
     po_cov_list = (

--- a/src/timesfm3/timesfm3_forecaster_test.py
+++ b/src/timesfm3/timesfm3_forecaster_test.py
@@ -194,5 +194,110 @@ class TimesFM3ForecasterTest(unittest.TestCase):
       self.assertEqual(out.forecast.shape, (8,))
 
 
+class _RecordingFakeModel(FakeModel):
+  """FakeModel that records decode inputs and infers horizon like the real model."""
+
+  def __init__(self, **kwargs):
+    super().__init__(**kwargs)
+    self.calls = []
+
+  def decode(
+    self,
+    target,
+    autoregressive_index=0,
+    horizon=8,
+    past_only_covariates=None,
+    past_future_covariates=None,
+    mask=None,
+  ):
+    if past_future_covariates is not None:
+      horizon = past_future_covariates.shape[-1] - target.shape[-1]
+    self.calls.append(
+      dict(
+        target=target.clone(),
+        past_future_covariates=(
+          None if past_future_covariates is None else past_future_covariates.clone()
+        ),
+        horizon=horizon,
+      )
+    )
+    return super().decode(target, autoregressive_index, horizon, mask=mask)
+
+
+class TimesFM3ForecasterCovariateWindowTest(unittest.TestCase):
+  """Regression tests for past-future covariate windows under truncation."""
+
+  def setUp(self):
+    super().setUp()
+    self.config = timesfm3_forecaster._ModelConfig(
+      checkpoint_path="/fake/path",
+      per_core_batch_size=2,
+      input_patch_length=8,
+      output_patch_length=8,
+      median_quantile_index=1,
+    )
+    self._max_context = timesfm3_forecaster._MAX_CONTEXT_LENGTH
+    timesfm3_forecaster._MAX_CONTEXT_LENGTH = 16
+
+  def tearDown(self):
+    timesfm3_forecaster._MAX_CONTEXT_LENGTH = self._max_context
+    super().tearDown()
+
+  def _forecaster(self):
+    with mock.patch.object(
+      timesfm3_forecaster.TimesFM3Forecaster, "_init_model", autospec=True
+    ):
+      forecaster = timesfm3_forecaster.TimesFM3Forecaster(self.config)
+    forecaster.model = _RecordingFakeModel()
+    forecaster.device = torch.device("cpu")
+    return forecaster
+
+  def test_truncated_context_keeps_covariate_window_aligned(self):
+    # horizon=5 is not a multiple of output_patch_length=8, and the context
+    # (40) exceeds the model context (16), so the query is truncated.
+    forecaster = self._forecaster()
+    context = np.arange(40, dtype=np.float32)
+    pf_cov = np.arange(45, dtype=np.float32)  # context + horizon
+    outputs = list(
+      forecaster.predict_batch(
+        contexts=[context], horizon=5, past_future_covariates=[pf_cov]
+      )
+    )
+    call = forecaster.model.calls[-1]
+    target = call["target"][0, 0]
+    pf = call["past_future_covariates"][0, 0]
+    # The covariate window must start at the same time step as the target
+    # window and its future part must be exactly the requested horizon.
+    self.assertEqual(float(target[0]), float(pf[0]))
+    self.assertEqual(pf.shape[-1], target.shape[-1] + 5)
+    self.assertEqual(call["horizon"], 5)
+    self.assertEqual(outputs[0].forecast.shape, (5,))
+
+  def test_mixed_length_batch_with_covariates(self):
+    forecaster = self._forecaster()
+    long_ctx = np.arange(40, dtype=np.float32)
+    short_ctx = np.arange(100, 112, dtype=np.float32)
+    outputs = list(
+      forecaster.predict_batch(
+        contexts=[long_ctx, short_ctx],
+        horizon=5,
+        past_future_covariates=[
+          np.arange(45, dtype=np.float32),
+          np.arange(100, 117, dtype=np.float32),
+        ],
+      )
+    )
+    self.assertEqual([o.forecast.shape for o in outputs], [(5,), (5,)])
+
+  def test_predict_batch_accepts_2d_array(self):
+    forecaster = self._forecaster()
+    outputs = list(
+      forecaster.predict_batch(
+        contexts=np.random.rand(3, 12).astype(np.float32), horizon=4
+      )
+    )
+    self.assertEqual(len(outputs), 3)
+
+
 if __name__ == "__main__":
   unittest.main()

--- a/src/timesfm3/timesfm3_forecaster_test.py
+++ b/src/timesfm3/timesfm3_forecaster_test.py
@@ -218,6 +218,9 @@ class _RecordingFakeModel(FakeModel):
         past_future_covariates=(
           None if past_future_covariates is None else past_future_covariates.clone()
         ),
+        past_only_covariates=(
+          None if past_only_covariates is None else past_only_covariates.clone()
+        ),
         horizon=horizon,
       )
     )
@@ -288,6 +291,83 @@ class TimesFM3ForecasterCovariateWindowTest(unittest.TestCase):
       )
     )
     self.assertEqual([o.forecast.shape for o in outputs], [(5,), (5,)])
+
+  def test_mixed_none_and_pf_covariates(self):
+    # A query without past-future covariates batched with one that has
+    # them: the placeholder must have the decode-expected width (matching
+    # the real PF arrays in the batch), or np.stack fails on lengths.
+    forecaster = self._forecaster()
+    long_ctx = np.arange(40, dtype=np.float32)
+    short_ctx = np.arange(100, 112, dtype=np.float32)
+    outputs = list(
+      forecaster.predict_batch(
+        contexts=[long_ctx, short_ctx],
+        horizon=5,
+        past_future_covariates=[np.arange(45, dtype=np.float32), None],
+      )
+    )
+    self.assertEqual([o.forecast.shape for o in outputs], [(5,), (5,)])
+    call = forecaster.model.calls[-1]
+    pf = call["past_future_covariates"]
+    # decode must see a uniform PF width across the batch. The batch
+    # context is capped by _MAX_CONTEXT_LENGTH(16, set in setUp), so the
+    # real PF is context(16) + requested horizon(5) = 21; the placeholder
+    # matches that width.
+    self.assertEqual(pf.shape[0], 2)
+    self.assertEqual(pf.shape[-1], 21)
+    pf_real = pf[0, 0]
+    pf_placeholder = pf[1, 0]
+    self.assertEqual(pf_real.shape[-1], pf_placeholder.shape[-1])
+    # The placeholder's future part (the requested horizon, 5) is zeros;
+    # decode infers horizon 5 from the width.
+    np.testing.assert_array_equal(pf_placeholder[-5:], np.zeros((5,), dtype=np.float32))
+    self.assertEqual(call["horizon"], 5)
+
+  def test_mixed_none_and_multichannel_covariates(self):
+    # Covariate channel count need not equal the number of target variates:
+    # a 2-channel past-future covariate and a 2-channel past-only covariate
+    # batched with a query that has neither must still stack.
+    forecaster = self._forecaster()
+    ctx_a = np.arange(12, dtype=np.float32)
+    ctx_b = np.arange(100, 112, dtype=np.float32)
+    pf_a = np.stack([np.arange(17, dtype=np.float32)] * 2)
+    po_a = np.stack([np.arange(12, dtype=np.float32)] * 2)
+    outputs = list(
+      forecaster.predict_batch(
+        contexts=[ctx_a, ctx_b],
+        horizon=5,
+        past_only_covariates=[po_a, None],
+        past_future_covariates=[pf_a, None],
+      )
+    )
+    self.assertEqual([o.forecast.shape for o in outputs], [(5,), (5,)])
+    call = forecaster.model.calls[-1]
+    # batch context 16 (12 rounded up to the patch), 2 channels, future 5.
+    self.assertEqual(tuple(call["past_future_covariates"].shape), (2, 2, 21))
+    self.assertEqual(tuple(call["past_only_covariates"].shape), (2, 2, 16))
+    np.testing.assert_array_equal(
+      call["past_future_covariates"][1].numpy(), np.zeros((2, 21), np.float32)
+    )
+    np.testing.assert_array_equal(
+      call["past_only_covariates"][1].numpy(), np.zeros((2, 16), np.float32)
+    )
+
+  def test_mixed_none_covariates_multivariate_target(self):
+    # Three target variates with a 2-channel past-future covariate on one
+    # query and none on the other.
+    forecaster = self._forecaster()
+    ctx_a = np.stack([np.arange(12, dtype=np.float32)] * 3)
+    ctx_b = np.stack([np.arange(100, 112, dtype=np.float32)] * 3)
+    pf_a = np.stack([np.arange(17, dtype=np.float32)] * 2)
+    outputs = list(
+      forecaster.predict_batch(
+        contexts=[ctx_a, ctx_b], horizon=5, past_future_covariates=[pf_a, None]
+      )
+    )
+    self.assertEqual([o.forecast.shape for o in outputs], [(3, 5), (3, 5)])
+    call = forecaster.model.calls[-1]
+    self.assertEqual(tuple(call["target"].shape), (2, 3, 16))
+    self.assertEqual(tuple(call["past_future_covariates"].shape), (2, 2, 21))
 
   def test_predict_batch_accepts_2d_array(self):
     forecaster = self._forecaster()


### PR DESCRIPTION
`_Query.format` slices `past_future_covariates` by `context_len + self.horizon`,
where `self.horizon` is the horizon rounded up to `output_patch_length`. With the
default `padding_mode="none"` the covariate's future part has the *requested*
horizon, so two things go wrong once a context is longer than the model context
(15360) and the horizon is not a multiple of the output patch length:

- single query: the covariate window starts (rounded - requested) steps before the
  target window, up to 63 steps, silently (TimesFM3Torch.decode infers the horizon
  from the covariate length, so nothing raises);
- a batch mixing a truncated query with a padded one: covariate arrays of different
  lengths reach `np.stack` and raise "all input arrays must have the same shape".

Fix: slice by the covariate's own future length. `predict_batch` also rejected a 2-D
ndarray of contexts at the `if not contexts` guard; use `len()`.

Not triggered by the README example (context 128, horizon 24): the context never
exceeds the model context, so the truncation branch is not taken.

Tests: three regression tests drive the forecaster through a recording fake model
that infers the horizon from the covariate length the way `TimesFM3Torch.decode`
does. All three fail on master and pass with the fix.

```
PYTHONPATH=src python -m pytest src/timesfm3 -q            # 48 passed
PYTHONPATH=src python -m pytest tests -q --ignore=tests/test_model_loading.py   # 59 passed
ruff check src/timesfm3 && ruff format --check src/timesfm3/timesfm3_forecaster.py
```

Placeholder shapes: a query without covariates in a batch where others have
them gets a zero placeholder shaped like the batch's real covariate arrays
(channel count and width), so mixed batches — including multi-channel
covariates on multi-variate targets — stack correctly.