### PR TITLE
fix(tests): skip test_model_loading when the [flax] extra is missing

### DIFF
--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -20,11 +20,7 @@ import types
 
 import pytest
 
-pytest.importorskip("einshape", reason="requires the [flax] extra (einshape)")
-pytest.importorskip("flax", reason="requires the [flax] extra")
-
 from timesfm.timesfm_2p5.timesfm_2p5_torch import TimesFM_2p5_200M_torch
-from timesfm.timesfm_2p5.timesfm_2p5_flax import TimesFM_2p5_200M_flax
 
 
 class TestModelLoading:
@@ -94,6 +90,12 @@ class TestModelLoading:
 
   def test_flax_model_init_kwargs(self):
     """Verifies that Flax model wrapper constructor accepts arbitrary kwargs."""
+    pytest.importorskip(
+        "einshape", reason="requires the [flax] extra (einshape)"
+    )
+    pytest.importorskip("flax", reason="requires the [flax] extra")
+    from timesfm.timesfm_2p5.timesfm_2p5_flax import TimesFM_2p5_200M_flax
+
     tfm = TimesFM_2p5_200M_flax(
         proxies={"http": "http://dummy.proxy"},
         custom_kwarg="dummy_value",

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -18,6 +18,11 @@ import os
 import tempfile
 import types
 
+import pytest
+
+pytest.importorskip("einshape", reason="requires the [flax] extra (einshape)")
+pytest.importorskip("flax", reason="requires the [flax] extra")
+
 from timesfm.timesfm_2p5.timesfm_2p5_torch import TimesFM_2p5_200M_torch
 from timesfm.timesfm_2p5.timesfm_2p5_flax import TimesFM_2p5_200M_flax
 


### PR DESCRIPTION
`tests/test_model_loading.py` imports the flax backend at module top level:

```python
from timesfm.timesfm_2p5.timesfm_2p5_flax import TimesFM_2p5_200M_flax
```

On a torch-only install (`pip install ".[torch]"`), `flax` and `einshape` are
absent (both are optional extras), so pytest fails at **collection time** and the
59 unrelated tests are lost with it (raised by sylvesterkaczmarek in review: three
of the four tests in this file are PyTorch-only, so a module-level skip also
removed the Torch model-loading and `torch.compile` coverage).

Gate only the one flax test on its optional dependencies. The flax import and both
`importorskip` calls now live inside `test_flax_model_init_kwargs`.

**a. minimal install (no flax extra):**

```
PYTHONPATH=src python -m pytest tests/test_model_loading.py -v
# test_torch_load_checkpoint_and_from_pretrained_local PASSED
# test_torch_compile_wraps_forward PASSED
# test_torch_no_compile_leaves_forward_unchanged PASSED
# test_flax_model_init_kwargs SKIPPED — "requires the [flax] extra"
# 3 passed, 1 skipped
```

**b. with the [flax] extra installed:**

```
PYTHONPATH=src python -m pytest tests/test_model_loading.py -v
# 4 passed
```

Full suite (`PYTHONPATH=src python -m pytest tests -q`): 63 passed. The skip
reason names the missing extra, so a user who actually wants the flax test gets
an actionable message. Related: #480.
