### PR TITLE
Fix TimesFM3 KV cache indexing for batched decoding

### DIFF
--- a/src/timesfm3/transformer.py
+++ b/src/timesfm3/transformer.py
@@ -296,9 +296,15 @@ class MultiHeadAttention(nn.Module):
     if decode_cache is not None:
       # Cached decoding: update cache with new K, V
       cache_size = decode_cache.key.shape[1]
-      idx = next_index[0].item()  # assumes uniform batch
-      decode_cache.key[:, idx : idx + n_patches, :, :] = key
-      decode_cache.value[:, idx : idx + n_patches, :, :] = value
+      if torch.all(next_index == next_index[0]):
+        idx = next_index[0].item()
+        decode_cache.key[:, idx : idx + n_patches, :, :] = key
+        decode_cache.value[:, idx : idx + n_patches, :, :] = value
+      else:
+        for b_idx in range(batch_size):
+          idx_b = next_index[b_idx].item()
+          decode_cache.key[b_idx, idx_b : idx_b + n_patches, :, :] = key[b_idx]
+          decode_cache.value[b_idx, idx_b : idx_b + n_patches, :, :] = value[b_idx]
       key = decode_cache.key
       value = decode_cache.value
 

--- a/src/timesfm3/transformer_test.py
+++ b/src/timesfm3/transformer_test.py
@@ -94,6 +94,72 @@ class MultiHeadAttentionTest(unittest.TestCase):
     self.assertIsNotNone(updated_cache)
     self.assertEqual(updated_cache.next_index[0].item(), 1)
 
+  def test_mha_decode_heterogeneous_batch(self):
+    """Verifies that heterogeneous sequence offsets within a batch do not corrupt KV cache."""
+    torch.manual_seed(42)
+    heads, d, hd, cache_len = 4, 64, 16, 16
+    mha = torch_trans.MultiHeadAttention(
+      num_heads=heads,
+      in_features=d,
+      causal_attention=True,
+      use_rotary_position_embeddings=True,
+      qk_norm="rms",
+      use_bias=False,
+      use_sdpa=True,
+    )
+    mha.eval()
+
+    # Sequence A has next_index = 1, Sequence B has next_index = 3
+    cache_a = torch_util.DecodeCache(
+      next_index=torch.tensor([1], dtype=torch.int32),
+      num_front_masked=torch.zeros(1, dtype=torch.int32),
+      key=torch.randn(1, cache_len, heads, hd),
+      value=torch.randn(1, cache_len, heads, hd),
+    )
+    cache_b = torch_util.DecodeCache(
+      next_index=torch.tensor([3], dtype=torch.int32),
+      num_front_masked=torch.zeros(1, dtype=torch.int32),
+      key=torch.randn(1, cache_len, heads, hd),
+      value=torch.randn(1, cache_len, heads, hd),
+    )
+
+    q_a = torch.randn(1, 1, d)
+    q_b = torch.randn(1, 1, d)
+    mask_1 = torch.zeros(1, 1, dtype=torch.bool)
+    mask_2 = torch.zeros(2, 1, dtype=torch.bool)
+
+    # Independent forward passes
+    out_a, updated_cache_a, _ = mha(q_a, patch_mask=mask_1, decode_cache=cache_a)
+    out_b, updated_cache_b, _ = mha(q_b, patch_mask=mask_1, decode_cache=cache_b)
+
+    # Batched forward pass
+    batched_cache = torch_util.DecodeCache(
+      next_index=torch.tensor([1, 3], dtype=torch.int32),
+      num_front_masked=torch.zeros(2, dtype=torch.int32),
+      key=torch.cat([cache_a.key, cache_b.key], dim=0),
+      value=torch.cat([cache_a.value, cache_b.value], dim=0),
+    )
+    q_batched = torch.cat([q_a, q_b], dim=0)
+    out_batched, updated_batched_cache, _ = mha(
+      q_batched, patch_mask=mask_2, decode_cache=batched_cache
+    )
+
+    # Batched outputs and caches must match independent outputs and caches
+    torch.testing.assert_close(out_batched[0:1], out_a, rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(out_batched[1:2], out_b, rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(
+      updated_batched_cache.key[0:1], updated_cache_a.key, rtol=1e-5, atol=1e-5
+    )
+    torch.testing.assert_close(
+      updated_batched_cache.key[1:2], updated_cache_b.key, rtol=1e-5, atol=1e-5
+    )
+    torch.testing.assert_close(
+      updated_batched_cache.value[0:1], updated_cache_a.value, rtol=1e-5, atol=1e-5
+    )
+    torch.testing.assert_close(
+      updated_batched_cache.value[1:2], updated_cache_b.value, rtol=1e-5, atol=1e-5
+    )
+
 
 class MixingTransformerTest(unittest.TestCase):
   def test_mixing_transformer_forward(self):


### PR DESCRIPTION
Summary:
Fix a KV-cache indexing bug in TimesFM3 during heterogeneous batched decoding.

Root Cause:
decode_cache.next_index is a per-sequence tensor with shape (batch_size,), but the KV-cache update used next_index[0] as the cache position for the entire batch.

This works when all sequences have the same decode position, but produces incorrect cache writes when sequences have different lengths.

For example, with:
Sequence A: next_index = 1
Sequence B: next_index = 3

the previous implementation used position 1 for both sequences, causing Sequence B's KV states to be written to the wrong cache position.

Reproduction:
Comparing independent inference with batched inference:
Homogeneous batch: PASSED
Heterogeneous batch: FAILED
Maximum absolute difference: 0.2835718
Mean absolute difference: 0.0762394

Fix:
Preserve the existing vectorized cache update for uniform next_index.
For heterogeneous batches, update each batch element using its own next_index.

Regression Test:
Added test_mha_decode_heterogeneous_batch to verify that heterogeneous batched decoding matches independent decoding.

Validation:
transformer_test.py: 8 passed
primitives_test.py: 20 passed
test_torch_layers.py: 16 passed
test_torch_utils.py: 16 passed
test_base_utils.py: 16 passed
test_configs.py: 10 passed
test_force_flip_invariance.py: 1 passed

87 tests passed, 0 failed.

Ruff checks also pass.