### PR TITLE
fix: reject unsupported swiglu activation

### DIFF
--- a/src/timesfm3/configs.py
+++ b/src/timesfm3/configs.py
@@ -44,7 +44,7 @@ class TransformerConfig:
   use_bias: bool
   use_rope_seq: bool
   use_rope_var: bool
-  ff_activation: Literal["relu", "swish", "none", "swiglu"]
+  ff_activation: Literal["relu", "swish", "none"]
   deterministic: bool
   v_norm: Literal["rms", "none"] = "none"
   causal_attention: bool = True

--- a/src/timesfm3/primitives_test.py
+++ b/src/timesfm3/primitives_test.py
@@ -163,8 +163,8 @@ class UtilTest(unittest.TestCase):
     swish = torch_util.get_activation_fn("swish")
     np.testing.assert_allclose(swish(x).numpy(), expected_silu.numpy())
 
-    swiglu = torch_util.get_activation_fn("swiglu")
-    np.testing.assert_allclose(swiglu(x).numpy(), expected_silu.numpy())
+    with self.assertRaisesRegex(ValueError, "swiglu"):
+      torch_util.get_activation_fn("swiglu")
 
   def test_decode_cache(self):
     num_layers = 2

--- a/src/timesfm3/util.py
+++ b/src/timesfm3/util.py
@@ -300,7 +300,6 @@ _ACTIVATIONS: dict[str, Callable[[torch.Tensor], torch.Tensor]] = {
   "relu": F.relu,
   "swish": F.silu,
   "silu": F.silu,
-  "swiglu": F.silu,
   "none": lambda x: x,
 }
 


### PR DESCRIPTION
SwiGLU (Shazeer, 2020) requires two separate linear projections (gate + value), not an element-wise activation function.

Previously, 'swiglu' was silently mapped to F.silu in _ACTIVATIONS, causing get_activation_fn('swiglu') to return a plain SiLU function while misleading callers into thinking the model used a gated FFN.

Changes:
- Remove 'swiglu' from _ACTIVATIONS in util.py so it now raises ValueError via the existing error path
- Remove 'swiglu' from the ff_activation Literal type in configs.py so static type checkers also reject it
- Update primitives_test.py: the test that verified swiglu == silu (which confirmed the bug) is replaced with a regression test that asserts ValueError is raised

No FFN parameterization or checkpoint tensor shapes are affected; all supported activations (relu, swish, silu, none) are unchanged.

Testing:All 20 tests in primitives_test.py pass.